### PR TITLE
v2.6.7

### DIFF
--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
-  * POTI-board改二 v2.5.0 lot.200520
+  * POTI-board改二 v2.6.7 lot.200622
   * by sakots >> https://poti-k.info/
   *
   * POTI-board改二の設定ファイルです。
@@ -18,7 +18,7 @@ define('LOG_MAX', '1000');
 //テーマ(テンプレート)のディレクトリ。'/'まで
 //themeディレクトリに使いたいtemplateをいれて使ってください。(推奨)
 //別のディレクトリにしたい場合は設定してください。
-//例えばおまけのnee2を使いたい場合はtheme_nee2/とすることができます。初期値は theme/ です。
+//例えばおまけのnee2を使いたい場合は theme_nee2/ とすることができます。初期値は theme/ です。
 define('SKIN_DIR', 'theme/');
 
 //メール通知のほか、シェアボタンなどで使用

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -38,14 +38,14 @@ define('USE_DUMP_FOR_DEBUG','0');
 
 配布条件はレッツPHP!に準じます。改造、再配布は自由にどうぞ。
 
-このスクリプトの改造部分に関する質問は「レッツPHP!」,
+このスクリプトの改造部分に関する質問は「レッツPHP!」
 「ふたば★ちゃんねる」「ぷにゅねっと」に問い合わせないでください。
 ご質問は、<https://poti-k.info/>までどうぞ。
 */
 
 //バージョン
-define('POTI_VER' , 'v2.6.6');
-define('POTI_VERLOT' , 'v2.6.6 lot.200609');
+define('POTI_VER' , 'v2.6.7');
+define('POTI_VERLOT' , 'v2.6.7 lot.200622');
 
 if(phpversion()>="5.5.0"){
 //スパム無効化関数
@@ -198,7 +198,7 @@ if(!defined('ELAPSED_DAYS')){//config.phpで未定義なら0
 }
 //テーマに設定が無ければ代入
 if(!defined('DEF_FONTCOLOR')){//文字色選択初期値
-	define('DEF_FONTCOLOR','null');
+	define('DEF_FONTCOLOR',null);
 }
 
 if(!defined('ADMIN_DELGUSU')||!defined('ADMIN_DELKISU')){//管理画面の色設定


### PR DESCRIPTION
`//テーマに設定が無ければ代入
if(!defined('DEF_FONTCOLOR')){//文字色選択初期値
	define('DEF_FONTCOLOR',null);
}
`
定数の null ではなく、文字列の null が入っていました。
しかしログファイルへの格納とは関係ない表示関連で、ここが未設定のテーマは文字色変更に対応していない事から実用上の問題は無かったものと思われます。