### PR TITLE
v2.6.8

### DIFF
--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
-  * POTI-board改二 v2.6.7 lot.200622
+  * POTI-board改二 v2.6.8 lot.200625
   * by sakots >> https://poti-k.info/
   *
   * POTI-board改二の設定ファイルです。
@@ -189,10 +189,8 @@ define('UNDO', '90');
 //アンドゥを幾つにまとめて保存しておくか(デフォルト)
 define('UNDO_IN_MG', '45');
 
-//画像のデータがこの値より大きくなるとき、
-//・保存タイプが AUTOの場合、JPEGに変換
-//・保存タイプが PNG の場合、減色処理
-//ただし、保存タイプが JPEGの場合は、この値を無視してJPEGに変換
+//画像のデータがこの値より大きくなる時はJPEGに変換
+//アップロードしたpng画像もここの設定値より大きな時はJPEGになります
 define('IMAGE_SIZE', '800');
 
 //PNGの減色率とJPEGの圧縮率
@@ -352,7 +350,7 @@ define('USE_THUMB', '1');
 define('THUMB_SELECT', '0');
 
 //サムネイルの品質  0(品質は最低、サイズは小)～100(品質は最高、サイズは大)の範囲内
-define('THUMB_Q', '75');
+define('THUMB_Q', '92');
 
 //GD2のImageCopyResampledでサムネイルの画質向上 させる:1 させない:0
 //自動判別なので通常は 1 でOK.不具合がある場合のみ 0 にして下さい

--- a/potiboard2/picpost.php
+++ b/potiboard2/picpost.php
@@ -1,6 +1,6 @@
 <?php
 //----------------------------------------------------------------------
-// picpost.php lot.200302  by SakaQ >> http://www.punyu.net/php/
+// picpost.php lot.200625  by SakaQ >> http://www.punyu.net/php/
 // & sakots >> https://poti-k.info/
 //
 // しぃからPOSTされたお絵かき画像をTEMPに保存
@@ -8,6 +8,7 @@
 // このスクリプトはPaintBBS（藍珠CGI）のPNG保存ルーチンを参考に
 // PHP用に作成したものです。
 //----------------------------------------------------------------------
+// 2020/05/25 投稿容量制限の設定項目を追加 従来はconfigのMAX_KB
 // 2020/02/25 flock()修正タイムゾーンを'Asia/Tokyo'に
 // 2020/01/25 REMOTE_ADDRが取得できないサーバに対応
 // 2019/12/03 軽微なエラー修正。datファイルのパーミッションを600に
@@ -31,6 +32,8 @@ include(__DIR__.'/config.php');
 date_default_timezone_set('Asia/Tokyo');
 //容量違反チェックをする する:1 しない:0
 define('SIZE_CHECK', '1');
+//投稿容量制限 KB
+define('PICPOST_MAX_KB', '3072');//3MBまで
 
 $time = time();
 $imgfile = $time.substr(microtime(),2,3);	//画像ファイル名
@@ -95,7 +98,7 @@ $headerLength = substr($buffer, 1, 8);
 // 画像ファイルの長さを取り出す
 $imgLength = substr($buffer, 1 + 8 + $headerLength, 8);
 // 投稿容量制限を超えていたら保存しない
-if(SIZE_CHECK && ($imgLength > MAX_KB * 1024)){
+if(SIZE_CHECK && ($imgLength > PICPOST_MAX_KB * 1024)){
 	error("規定容量オーバー。お絵かき画像は保存されません。");
 	exit;
 }

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -44,8 +44,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.6.7');
-define('POTI_VERLOT' , 'v2.6.7 lot.200622');
+define('POTI_VER' , 'v2.6.8');
+define('POTI_VERLOT' , 'v2.6.8 lot.200625');
 
 if(phpversion()>="5.5.0"){
 //スパム無効化関数
@@ -332,13 +332,13 @@ function form(&$dat,$resno,$admin="",$tmp=""){
 		$dat['ptime'] = $ptime;
 	}
 
-	$dat['maxbyte'] = MAX_KB * 1024;
+	$dat['maxbyte'] = 2048 * 1024;//フォームのHTMLによるファイルサイズの規制 2Mまで
 	$dat['usename'] = USE_NAME ? ' *' : '';
 	$dat['usesub']  = USE_SUB ? ' *' : '';
 	if(USE_COM||($resno&&!RES_UPLOAD)) $dat['usecom'] = ' *';
 	//本文必須の設定では無い時はレスでも画像かコメントがあれば通る
 	if((!$resno && !$tmp) || (RES_UPLOAD && !$tmp)) $dat['upfile'] = true;
-	$dat['maxkb']   = MAX_KB;
+	$dat['maxkb']   = MAX_KB;//実際にアップロードできるファイルサイズ
 	$dat['maxw']    = $resno ? MAX_RESW : MAX_W;
 	$dat['maxh']    = $resno ? MAX_RESH : MAX_H;
 	$dat['addinfo'] = $addinfo;
@@ -889,7 +889,16 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 		else{
 			$is_file_dest=true;
 		} 
-		if(filesize($dest) > MAX_KB * 1024){error(MSG034,$dest);} 	//追加(v1.32)
+		if(filesize($dest) > IMAGE_SIZE * 1024 || filesize($dest) > MAX_KB * 1024){//指定サイズを超えていたら
+			if(mime_content_type($dest)==="image/png" && gd_check()&&function_exists("ImageCreateFromPNG")){//pngならJPEGに変換
+				$im_in=ImageCreateFromPNG($dest);
+				ImageJPEG($im_in,$dest,92);
+			}
+		}
+		clearstatcache();
+		if(filesize($dest) > MAX_KB * 1024){//ファイルサイズ再チェック
+		error(MSG034,$dest);
+		}
 		$size = getimagesize($dest);
 		$img_type=mime_content_type($dest);//190603
 		if($img_type==="image/gif"||$img_type==="image/jpeg"||$img_type==="image/png"){//190603
@@ -2374,7 +2383,7 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 	$com = str_replace("\r", "\n", $com);
 	// 連続する空行を一行
 	$com = preg_replace("#\n((　| )*\n){3,}#","\n",$com);
-	$com = nl2br($com,);		//改行文字の前に<br>を代入する
+	$com = nl2br($com);		//改行文字の前に<br>を代入する
 	$com = str_replace("\n", "", $com);	//\nを文字列から消す
 
 	$name=preg_replace("/◆/","◇",$name);
@@ -2549,12 +2558,19 @@ function replace($no,$pwd,$stime){
 	//画像差し替えに管理パスは使っていない
 		if($eno == $no && (password_verify($pwd,$epwd)||$epwd=== substr(md5($pwd),2,8))){
 			$upfile = $temppath.$file_name.$imgext;
-			$dest = $path.$tim.$imgext;
+			$dest = $path.$tim;//拡張子なし
 			copy($upfile, $dest);
+
+			if(filesize($dest) > IMAGE_SIZE * 1024 || filesize($dest) > MAX_KB * 1024){//指定サイズを超えていたら
+				if(mime_content_type($dest)==="image/png" && gd_check() && function_exists("ImageCreateFromPNG")){//pngならJPEGに変換
+					$im_in=ImageCreateFromPNG($dest);
+					ImageJPEG($im_in,$dest,92);
+				}
+			}
+
 			if(!is_file($dest)) error(MSG003,$dest);
-			// $size = getimagesize($dest);
-			//			if(!is_array($size)) error(MSG004,$dest);
-		$img_type=mime_content_type($dest);//190603
+
+		$img_type=mime_content_type($dest);
 		if($img_type==="image/gif"||$img_type==="image/jpeg"||$img_type==="image/png"){//190603
 			$chk = md5_file($dest);
 			foreach($badfile as $value){
@@ -2562,8 +2578,15 @@ function replace($no,$pwd,$stime){
 				error(MSG005,$dest); //拒絶画像
 				}
 			}
-
+			switch ($img_type) {//拡張子
+				case "image/gif" : $imgext=".gif";break;
+				case "image/jpeg" : $imgext=".jpg";break;
+				case "image/png" : $imgext=".png";break;
+				default : error(MSG004,$dest);
+			}
+	
 			chmod($dest,0606);
+			rename($dest,$dest.$imgext);
 			$mes = "画像のアップロードが成功しました<br><br>";
 			}
 		else{

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -332,7 +332,7 @@ function form(&$dat,$resno,$admin="",$tmp=""){
 		$dat['ptime'] = $ptime;
 	}
 
-	$dat['maxbyte'] = 2048 * 1024;//フォームのHTMLによるファイルサイズの規制 2Mまで
+	$dat['maxbyte'] = 2048 * 1024;//フォームのHTMLによるファイルサイズの制限 2Mまで
 	$dat['usename'] = USE_NAME ? ' *' : '';
 	$dat['usesub']  = USE_SUB ? ' *' : '';
 	if(USE_COM||($resno&&!RES_UPLOAD)) $dat['usecom'] = ' *';


### PR DESCRIPTION
php5.6,php7.2の時に致命的エラーが発生していたv2.6.3以降のバージョンの文法ミスを修正。
画像アップロードやNEOのPNGファイルも設定したファイルサイズの上限を超過した時はJPEGに変換、そのJPEG画像がファイルサイズに違反していなければ投稿できるようにした。
それにともないHTMLのフォームによるファイルサイズの制限を2MB、picpost.phpで受信できる画像のファイルサイズを3MBにそれぞれ緩和。