### PR TITLE
規定容量を超えるとJPEGに変換。JPEGとPNGを比較してファイルサイズが小さなほうを出力。

### DIFF
--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
-  * POTI-board改二 v2.7.3 lot.200708
+  * POTI-board改二 v2.7.4 lot.200711
   * by sakots >> https://poti-k.info/
   *
   * POTI-board改二の設定ファイルです。
@@ -189,10 +189,11 @@ define('UNDO', '90');
 //アンドゥを幾つにまとめて保存しておくか(デフォルト)
 define('UNDO_IN_MG', '45');
 
-//投稿されたPNG画像のファイルサイズがこの値より大きな時はJPEGに変換
-//アップロードしたPNG画像もこの設定値より大きな時はJPEGになります
+//PNG画像のファイルサイズが設定値より大きな時はJPEGに変換
+//アップロードしたPNG画像もJPEGに変換します
+//JPEGに変換した画像ともとのPNG画像を比較してファイルサイズが小さなほうを投稿します
 //単位kb
-define('IMAGE_SIZE', '512');
+define('IMAGE_SIZE', '512');	
 
 //PNGの減色率とJPEGの圧縮率
 //要対応テーマ


### PR DESCRIPTION
```
//単位kb
define('IMAGE_SIZE', '512');
```	
の指定ファイルサイズより大きなPNG形式の画像を**JPEGに変換**する機能を実装しましたが、
画像によっては**JPEGのほうがファイルサイズが大きくなる**事がわかりました。

そのため、いったんJPEGで出力してファイルサイズが**PNGより小さければJPEG**で、でなければPNGのまま出力する処理を追加しました。

> PNGで最適な圧縮がされるデータもJPEG化されます。 逆に大きくなりかねませんので、キャンバスの大きさにもよりますが、最低40は 指定する様にして下さい。60KByte奨励。
> http://hp.vector.co.jp/authors/VA016309/paintbbs/document/Readme_Shichan.html

今回のPNG、JPEG容量比較処理の追加で**逆に大きくなる事はなくなりました**。