### PR TITLE
画像アップロード禁止でコメントのみの投稿も禁止の時は投稿フォームをださない。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -43,8 +43,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.7.9');
-define('POTI_VERLOT' , 'v2.7.9 lot.200725');
+define('POTI_VER' , 'v2.8.0');
+define('POTI_VERLOT' , 'v2.8.0 lot.200726');
 
 if(phpversion()>="5.5.0"){
 //スパム無効化関数
@@ -276,10 +276,14 @@ function head(&$dat){
 	$dat['userdel'] = USER_DELETES;
 	$dat['charset'] = 'UTF-8';
 	$dat['skindir'] = SKIN_DIR;
+	$dat['for_new_post'] = true;
+	if(!USE_IMG_UPLOAD&&DENY_COMMENTS_ONLY){
+		$dat['for_new_post'] = false;
+	}
 
 //OGPイメージ シェアボタン
 	$dat['rooturl'] = ROOT_URL;//設置場所url
-	if (defined ('SHARE_BUTTON') && SHARE_BUTTON){
+	if (SHARE_BUTTON){
 		$dat['sharebutton'] = true;//1ならシェアボタンを表示
 	}
 	
@@ -292,6 +296,13 @@ function form(&$dat,$resno,$admin="",$tmp=""){
 	global $ADMIN_PASS;
 
 	$dat['form'] = true;
+	if(!USE_IMG_UPLOAD && DENY_COMMENTS_ONLY && !$resno && !$admin){//コメントのみも画像アップロードも禁止
+		$dat['form'] = false;//トップページのフォームを閉じる
+		if(USE_PAINT==1 && !$resno && !$admin){
+			$dat['paint2'] = true;
+		}
+
+	}
 	if(USE_PAINT){
 
 		$dat['pdefw'] = PDEF_W;
@@ -300,10 +311,12 @@ function form(&$dat,$resno,$admin="",$tmp=""){
 		$dat['animechk'] = DEF_ANIME ? ' checked' : '';
 		$dat['pmaxw'] = PMAX_W;
 		$dat['pmaxh'] = PMAX_H;
+		// $dat['form'] = true;
 		if(USE_PAINT==2 && !$resno && !$admin){
 			$dat['paint2'] = true;
 			$dat['form'] = false;
 		}
+
 	}
 
 	if($resno){
@@ -349,7 +362,7 @@ function form(&$dat,$resno,$admin="",$tmp=""){
 	if(USE_COM||($resno&&!RES_UPLOAD)) $dat['usecom'] = ' *';
 	//本文必須の設定では無い時はレスでも画像かコメントがあれば通る
 	// if((!$resno && !$tmp) || (RES_UPLOAD && !$tmp)) $dat['upfile'] = true;
-	if(!USE_IMG_UPLOAD){//画像アップロード機能を使わない時
+	if(!USE_IMG_UPLOAD && !$admin){//画像アップロード機能を使わない時
 		$dat['upfile'] = false;
 	}
 	else{
@@ -1391,7 +1404,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 	}
 
 	header("Content-type: text/html; charset=UTF-8");
-if(defined('URL_PARAMETER') && URL_PARAMETER){
+if(URL_PARAMETER){
 		$urlparameter = "?$time";//パラメータをつけてキャッシュを表示しないようにする工夫。
 	}else{
 		$urlparameter = "";
@@ -2501,7 +2514,7 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 	updatelog();
 
 	header("Content-type: text/html; charset=UTF-8");
-	if(defined('URL_PARAMETER') && URL_PARAMETER){
+	if(URL_PARAMETER){
 		$urlparameter = "?$time";//パラメータをつけてキャッシュを表示しないようにする工夫。
 	}else{
 		$urlparameter = "";
@@ -2729,7 +2742,7 @@ function replace($no,$pwd,$stime){
 	updatelog();
 
 	header("Content-type: text/html; charset=UTF-8");
-if(defined('URL_PARAMETER') && URL_PARAMETER){
+if(URL_PARAMETER){
 		$urlparameter = "?$time";//パラメータをつけてキャッシュを表示しないようにする工夫。
 	}else{
 		$urlparameter = "";


### PR DESCRIPTION
### 投稿できない設定の時はトップページの投稿フォームを閉じる
![Screen-2020-07-26_01-04-46](https://user-images.githubusercontent.com/44894014/88464081-d1790c00-cef2-11ea-9815-1c2dd7d54852.png)
コメントのみの投稿を禁止して、画像アップロード機能も使わない時に、トップページの投稿欄が開いていても何も投稿できないので設定がふたつ重なった時は自動的にこのフォームを閉じるようにしました。

> //お絵かき機能を使用する お絵かきのみ:2 する:1 しない:0
> define('USE_PAINT', '1');
> 

ここが2なら、最初からこのフォームはでません。
1なら、ペイントボタンと一緒にフォームがでていました。

![Screen-2020-07-26_01-05-35](https://user-images.githubusercontent.com/44894014/88464140-5c5a0680-cef3-11ea-8d37-80285f91f314.png)
↑
コメントも画像も投稿できない時点で、1ならお絵かき機能しかつかえないので、
2のお絵かきのみと同じ動作になるようにしました。

**管理パスで編集時にアップロード欄が表示されるバグを修正**

管理パスで編集時、正常動作であればでない筈の画像アップロード欄が出るバグを修正。
テーマの該当のHTMLをもとに戻し、

`<% def(upfile) %>`

の定義をみなおして
**「管理画面」では**
アップロード禁止でも

`<% def(upfile) %>`にtrueが入るようにしました。