### PR TITLE
必要のないコメント//独自タグ変換 を除去。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -661,7 +661,6 @@ function updatelog($resno=0){
 				$fontcolor = $fcolor ? $fcolor : DEF_FONTCOLOR;
 				//<br />を<br>へ
 				$com = preg_replace("{<br( *)/>}i","<br>",$com);
-				//独自タグ変換
 				$encoded_name=urlencode($name);
 
 				// レス記事一時格納


### PR DESCRIPTION
```
//独自タグ変換
$encoded_name=urlencode($name);
```
不要なコードを削除したあとに、//独自タグ変換 というコメントだけ残り
$encoded_name が独自タグ変換に関するものに読めてしまうので削除しました。
機能には関係ないので、バージョンの表記は同じです。