### PR TITLE
$mes . '画面を切り替えます'

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -43,8 +43,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.8.12');
-define('POTI_VERLOT' , 'v2.8.12 lot.200801');
+define('POTI_VER' , 'v2.8.13');
+define('POTI_VERLOT' , 'v2.8.13 lot.200801');
 
 if(phpversion()>="5.5.0"){
 //スパム無効化関数
@@ -1340,7 +1340,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 	redirect(
 		PHP_SELF2 . (URL_PARAMETER ? "?{$time}" : ''),
 		1,
-		'画面を切り替えます'
+		$mes . '画面を切り替えます'
 	);
 }
 


### PR DESCRIPTION
通常投稿の時に、
`$mes = "画像 $upfile_name のアップロードが成功しました<br><br>";`
の箇所が表示されなくなっていたのを修正しました。
細かな修正すぎるうえ、更新が続いているため、READMEの更新は少しまったほうがいいのかも。