### PR TITLE
if(!$buf)

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -2,7 +2,6 @@
 define('USE_DUMP_FOR_DEBUG','0');
 //HTML出力の前に$datをdump しない:0 する:1 dumpしてexit：2 
 // ini_set('error_reporting', E_ALL);
-//$time_start = microtime(true);
 /*
   *
   * POTI-board改二 バージョン情報はちょっと下参照
@@ -43,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.9.4');
-define('POTI_VERLOT' , 'v2.9.4 lot.200802');
+define('POTI_VER' , 'v2.9.5');
+define('POTI_VERLOT' , 'v2.9.5 lot.200802');
 
 if(phpversion()>="5.5.0"){
 //スパム無効化関数
@@ -275,8 +274,6 @@ switch($mode){
 			redirect(PHP_SELF2, 0);
 		}
 }
-
-//$time = microtime(true) - $time_start; echo "{$time} 秒";
 
 exit;
 
@@ -1074,7 +1071,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$resto,$pictmp,$picfile){
 	flock($fp, LOCK_EX);
 	rewind($fp);
 	$buf=fread($fp,5242880);
-	if($buf==''){error(MSG019,$dest);}
+	if(!$buf){error(MSG019,$dest);}
 	$buf = charconvert($buf);
 	$line = explode("\n",$buf);
 	foreach($line as $i =>&$value){//$i必要
@@ -1287,7 +1284,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$resto,$pictmp,$picfile){
 	flock($tp, LOCK_EX); //*
 	rewind($tp);
 	$buf=fread($tp,5242880);
-	if($buf==''){error(MSG023,$dest);}
+	if(!$buf){error(MSG023,$dest);}
 	$line = explode("\n",$buf);
 		foreach($line as &$value){
 		if($value!==""){
@@ -1400,7 +1397,7 @@ function treedel($delno){
 	flock($fp, LOCK_EX);
 	rewind($fp);
 	$buf=fread($fp,5242880);
-	if($buf==''){error(MSG024);}
+	if(!$buf){error(MSG024);}
 	$line = explode("\n",$buf);
 	$countline=count($line);//必要
 	$find=false;
@@ -1474,7 +1471,7 @@ function usrdel($del,$pwd){
 		flock($fp, LOCK_EX);
 		rewind($fp);
 		$buf=fread($fp,5242880);
-		if($buf==''){error(MSG027);}
+		if(!$buf){error(MSG027);}
 		$buf = charconvert($buf);
 		$line = explode("\n",$buf);
 		foreach($line as &$value){
@@ -1545,7 +1542,7 @@ function admindel($pass){
 		flock($fp, LOCK_EX);
 		rewind($fp);
 		$buf=fread($fp,5242880);
-		if($buf==''){error(MSG030);}
+		if(!$buf){error(MSG030);}
 		$buf = charconvert($buf);
 		$line = explode("\n",$buf);
 		foreach($line as &$value){
@@ -1826,11 +1823,11 @@ if($admin===$ADMIN_PASS){
 			}
 		}
 	}
-	// form($dat,$resto);
 	$dat = array_merge($dat,form($resto));
-
-	$dat['mode2'] = $mode;
-	if($mode=="contpaint"){
+	if($mode==='paint'||$mode==='contpaint'){
+		$dat['mode2'] = $mode;
+	}
+	if($mode==="contpaint"){
 		$dat['no'] = $no;
 		$dat['pch'] = $pch;
 		$dat['ctype'] = $ctype;
@@ -2207,7 +2204,7 @@ function editform($del,$pwd){
 		fflush($fp);
 		flock($fp, LOCK_UN);
 		fclose($fp);
-		if($buf==''){error(MSG019);}
+		if(!$buf){error(MSG019);}
 		$buf = charconvert($buf);
 		$line = explode("\n",$buf);
 		foreach($line as &$value){
@@ -2410,7 +2407,7 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 	flock($fp, LOCK_EX);
 	rewind($fp);
 	$buf=fread($fp,5242880);
-	if($buf==''){error(MSG019);}
+	if(!$buf){error(MSG019);}
 	$buf = charconvert($buf);
 	$line = explode("\n",$buf);
 	foreach($line as &$value){
@@ -2535,7 +2532,7 @@ function replace($no,$pwd,$stime){
 	flock($fp, LOCK_EX);
 	rewind($fp);
 	$buf=fread($fp,5242880);
-	if($buf==''){error(MSG019);}
+	if(!$buf){error(MSG019);}
 	$buf = charconvert($buf);
 	$line = explode("\n",$buf);
 	foreach($line as &$value){


### PR DESCRIPTION
```
	if($mode==='paint'||$mode==='contpaint'){
		$dat['mode2'] = $mode;
	}
```
Switch文以外のモードの時はエラーになるので、指定モード以外の文字列は入らない筈ですが、外部入力ではなく途中で変数書き換えを行う可能性もあるため、念の為
paintまたはcontpaintしか$dat['mode2']にはいらないようにしました。
実は不要なのかもしれませんが…どうでしょう？
そして、
`if($buf==''){error(MSG023,$dest);}`
のように書いていた処理を、
`if(!$buf)`
に置き換えました。
falseでも空白でもエラーになるのはこれまでと同じです。