### PR TITLE
template_ini.phpのパスと未定義定数の確認

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -136,10 +136,10 @@ if ($err = check_file(__DIR__.'/Skinny.php')) {
 require_once(__DIR__.'/Skinny.php');
 
 //Template設定ファイル
-if ($err = check_file(__DIR__.'/'.SKIN_DIR.'/template_ini.php')) {
+if ($err = check_file(__DIR__.'/'.SKIN_DIR.'template_ini.php')) {
 	error($err);
 }
-require(__DIR__.'/'.SKIN_DIR.'/template_ini.php');
+require(__DIR__.'/'.SKIN_DIR.'template_ini.php');
 
 $path = realpath("./").'/'.IMG_DIR;
 $temppath = realpath("./").'/'.TEMP_DIR;

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -753,7 +753,7 @@ function error($mes,$dest=''){
 	safe_unlink($dest);
 	$dat['err_mode'] = true;
 	$dat['mes'] = $mes;
-	if (defined(OTHERFILE)) {
+	if (defined('OTHERFILE')) {
 		htmloutput(SKIN_DIR.OTHERFILE,$dat);
 	} else {
 		print $dat['mes'];


### PR DESCRIPTION
たとえば
```
<?php
	defined(OTHERFILE);
```
と書くと、
Warning: Use of undefined constant OTHERFILE - assumed 'OTHERFILE' (this will throw an Error in a future version of PHP)
となります。
マニュアル通りなら
```
<?php
/* 引用符の使い方に注意してください。これは重要です。この例では
 * 文字列 'TEST' が、定数 TEST の名前かどうかを調べています。*/
if (defined('TEST')) {
    echo TEST;
}
?>
```
SKIN_DIRには、ディレクトリ名の最後の/まで入っているので
`require(__DIR__.'/'.SKIN_DIR.'/template_ini.php');`
 theme//template_ini.php' とすると/が二重に入ります。
↓
`require(__DIR__.'/'.SKIN_DIR.'template_ini.php');`