### PR TITLE
if($res['w'] && $res['h']){の確認はここでは必要ない。画像ならサイズがあるという古いコードが残ったもの。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -2480,10 +2480,8 @@ function create_res ($path, $line) {
 		$res['src'] = IMG_DIR.$time.$ext;
 		$res['srcname'] = $time.$ext;
 		$res['size'] = filesize($res['img']);
-		if($res['w'] && $res['h']){	//サイズがある時
-			$res['thumb'] = is_file(THUMB_DIR.$time.'s.jpg');
-			$res['imgsrc'] = $res['thumb'] ? THUMB_DIR.$time.'s.jpg' : $res['src'];
-		}
+		$res['thumb'] = is_file(THUMB_DIR.$time.'s.jpg');
+		$res['imgsrc'] = $res['thumb'] ? THUMB_DIR.$time.'s.jpg' : $res['src'];
 		//描画時間
 		$res['painttime'] = DSP_PAINTTIME ? $ptime : '';
 		//動画リンク


### PR DESCRIPTION
古いコードたとえばv1.32のgetImagesizeでsizeが入ればそれは画像という判定処理が残った箇所を整理。
2行減っただけですが…。