### PR TITLE
カタログモードの画像のHTMLの縦横比の計算のバグ修正。どこにも使われていない定数USE_MBを削除。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -141,9 +141,6 @@ if((THUMB_SELECT==0 && gd_check()) || THUMB_SELECT==1){
 	}
 }
 
-//MB関数を使うか？ 使う:1 使わない:0
-define('USE_MB' , '1');
-
 //ユーザー削除権限 (0:不可 1:treeのみ許可 2:treeと画像のみ許可 3:tree,log,画像全て許可)
 //※treeのみを消して後に残ったlogは管理者のみ削除可能
 define('USER_DELETES', '3');
@@ -2200,8 +2197,8 @@ function catalog(){
 			if ($res['img_file_exists']) {
 				if($res['w'] && $res['h']){
 					if($res['w'] > CATALOG_W){
-						$res['w'] = CATALOG_W; //画像幅を揃える
 						$res['h'] = ceil($res['h'] * (CATALOG_W / $res['w']));//端数の切り上げ
+						$res['w'] = CATALOG_W; //画像幅を揃える
 					}
 				}else{//ログに幅と高さが記録されていない時
 					$res['w'] = CATALOG_W;


### PR DESCRIPTION
### カタログのHTMLの縦横比が正しくありませんでした。
画像の縦横比の計算の前に、template_ini.phpで設定した横幅を代入していたため、HTMLの縦横比がでていませんでした。
これは、私のミスです。

### 使用されていない定数USE_MBを削除
USE_MBという定数はどこにも使用されていないので削除しました。
念の為フォルダ内を検索もしてみましたがどのファイルに該当箇所はありませんでした。
コード整理の過程で不要になった定数です。
