### PR TITLE
thumbnail_gd.phpで幅と高さの返り値を取得できるようにした。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -2105,8 +2105,14 @@ function replace($no,$pwd,$stime){
 			rename($dest,$path.$tim.$imgext);
 			$mes = "画像のアップロードが成功しました<br><br>";
 
-			//差し換え前と同じ大きさのサムネイル作成
-			if(USE_THUMB) thumb($path,$tim,$imgext,$W,$H);
+			//元のサイズを基準にサムネイルを作成
+			if(USE_THUMB){
+				$thumbnail_size=array();
+					if($thumbnail_size=thumb($path,$tim,$imgext,$W,$H)){//作成されたサムネイルのサイズ
+						$W=$thumbnail_size['w'];
+						$H=$thumbnail_size['h'];
+					}
+				} 
 			//ワークファイル削除
 			safe_unlink($upfile);
 			safe_unlink($temppath.$file_name.".dat");

--- a/potiboard2/thumbnail_gd.php
+++ b/potiboard2/thumbnail_gd.php
@@ -63,5 +63,11 @@ function thumb($path,$tim,$ext,$max_w,$max_h){
 	// 作成したイメージを破棄
 	ImageDestroy($im_in);
 	ImageDestroy($im_out);
+	$thumbnail_size = [
+		'w' => $out_w,
+		'h' => $out_h,
+	];
+return $thumbnail_size;
+
 }
 ?>


### PR DESCRIPTION
### 画像をアップロードして続きを描くと縦横比が正しく表示されない事がある
これは、v1.32の頃からの問題です。
大きめの画像をアップロードして、続きを描くとAPPLETのキャンバスサイズにおさまりきらなくなり縦横比が変わってしまう事があります。
しかし、従来の画像差し換えの処理では、元のサイズと同じサイズのサムネイルを作成となっているため、実際の画像の縦横比とは異なる幅と高さがログに記録され、HTMLの幅と高さの縦横比も正しくありませんでした。

### thumbnail_gd.phpの返り値に幅と高さが入るように
もう一度縮小率の計算をして…とすると、レスの時と親の時とでサムネイルのサイズの設定が違う事があるので、それは無理…という事で、実際に作成されたサムネイルのサイズを返り値で取得できるようにしました。
これによりログとHTMLに、実際のサムネイルのサイズが入るようになりました。

そもそもHTMLの幅と高さを仕様していないテーマには影響がありません。またCSSでheight;auto;を使っていれば表示上の問題はないのかもしれないのですが、記録されているサイズが間違っている事には違いはないので、修正しました。

この更新を有効にするにはpotiboard.phpとthumbnail_gd.phpの2つを上書きする必要があります。
どちらか片方だけの上書きでも動作が以前と変わらないだけで支障はありません。

### 実例
![Screen-2020-08-26_19-13-57](https://user-images.githubusercontent.com/44894014/91293793-8002bc00-e7d3-11ea-9c5b-b180fb0e0047.png)
![Screen-2020-08-26_19-14-45](https://user-images.githubusercontent.com/44894014/91293808-85600680-e7d3-11ea-911f-fb893e4259e8.png)

従来は、393X400でサムネイルが作成されると、続きを描くでサイズが変わってもHTMLの幅と高さはサイズ変更前の393Ｘ400のままでした。
今回の修正後は、393X393。