### PR TITLE
描画時間計算のためのデータをuserdataに保存する形式に移行。picpost.phpの更新も必要。

### DIFF
--- a/potiboard2/picpost.php
+++ b/potiboard2/picpost.php
@@ -1,6 +1,6 @@
 <?php
 //----------------------------------------------------------------------
-// picpost.php lot.200625  by SakaQ >> http://www.punyu.net/php/
+// picpost.php lot.200828  by SakaQ >> http://www.punyu.net/php/
 // & sakots >> https://poti-k.info/
 //
 // しぃからPOSTされたお絵かき画像をTEMPに保存
@@ -8,6 +8,7 @@
 // このスクリプトはPaintBBS（藍珠CGI）のPNG保存ルーチンを参考に
 // PHP用に作成したものです。
 //----------------------------------------------------------------------
+// 2020/08/28 描画時間の記録に対応
 // 2020/05/25 投稿容量制限の設定項目を追加 従来はconfigのMAX_KB
 // 2020/02/25 flock()修正タイムゾーンを'Asia/Tokyo'に
 // 2020/01/25 REMOTE_ADDRが取得できないサーバに対応
@@ -201,8 +202,9 @@ if($sendheader){
 		list($name,$value) = explode("=", $query_s);
 		$$name = $value;
 	}
-	//usercodeと差し換え認識コード追加
-	$userdata .= "\t$usercode\t$repcode";
+	//usercode 差し換え認識コード 描画開始 完了時間 を追加
+	$userdata .= "\t$usercode\t$repcode\t$stime\t$time";
+
 }
 $userdata .= "\n";
 if(is_file(TEMP_DIR.$imgfile.".dat")){

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -259,7 +259,7 @@ switch($mode){
 		rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin);
 		break;
 	case 'picrep':
-		replace($no,$pwd,$stime);
+		replace($no,$pwd);
 		break;
 	case 'catalog':
 		catalog();
@@ -668,7 +668,7 @@ function similar_str($str1,$str2){
 /* 記事書き込み */
 function regist($name,$email,$sub,$com,$url,$pwd,$resto){
 	global $path,$badstring,$pwdc;
-	global $temppath,$ptime;
+	global $temppath;
 	global $fcolor,$usercode;
 	global $admin,$badstr_A,$badstr_B,$badname;
 	global $ADMIN_PASS;
@@ -713,8 +713,14 @@ function regist($name,$email,$sub,$com,$url,$pwd,$resto){
 		$fp = fopen($temppath.$picfile.".dat", "r");
 		$userdata = fread($fp, 1024);
 		fclose($fp);
-		list($uip,$uhost,,,$ucode,) = explode("\t", rtrim($userdata));
+		list($uip,$uhost,,,$ucode,,$starttime,$postedtime) = explode("\t", rtrim($userdata));
 		if(($ucode != $usercode) && (IP_CHECK && $uip != $userip)){error(MSG007);}
+
+		//描画時間を$userdataをもとに計算
+		if($starttime && DSP_PAINTTIME){
+			$ptime = calcPtime($starttime,$postedtime);
+		}
+	
 	}
 	$dest='';
 	$is_file_dest=false;
@@ -1582,6 +1588,7 @@ if($admin===$ADMIN_PASS){
 		$arr_dynp[] = '<option>'.$p.'</option>';
 	}
 	$dat['dynp']=implode('',$arr_dynp);
+	$usercode.='&amp;stime='.time();
 	$dat['usercode'] = $usercode;
 
 	$dat['useneo'] = $useneo; //NEOを使う
@@ -2013,7 +2020,7 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 }
 
 /* 画像差し換え */
-function replace($no,$pwd,$stime){
+function replace($no,$pwd){
 	global $path,$temppath,$repcode;
 	$userip = get_uip();
 	$mes="";
@@ -2030,7 +2037,7 @@ function replace($no,$pwd,$stime){
 			$fp = fopen(TEMP_DIR.$file, "r");
 			$userdata = fread($fp, 1024);
 			fclose($fp);
-			list($uip,$uhost,$uagent,$imgext,$ucode,$urepcode) = explode("\t", rtrim($userdata)."\t");//区切りの"\t"を行末に190610
+			list($uip,$uhost,$uagent,$imgext,$ucode,$urepcode,$starttime,$postedtime) = explode("\t", rtrim($userdata)."\t");//区切りの"\t"を行末に190610
 			$file_name = preg_replace("/\.(dat)$/i","",$file);
 			//画像があり、認識コードがhitすれば抜ける
 			if($file_name && is_file(TEMP_DIR.$file_name.$imgext) && $urepcode === $repcode){$find=true;break;}
@@ -2051,9 +2058,9 @@ function replace($no,$pwd,$stime){
 	$tim = KASIRA.$time.substr(microtime(),2,3);
 	$now = now_date($time);//日付取得
 	$now .= UPDATE_MARK;
-	//描画時間
-	if($stime && DSP_PAINTTIME){
-		$ptime = calcPtime($stime);
+	//描画時間を$userdataをもとに計算
+	if($starttime && DSP_PAINTTIME){
+		$ptime = calcPtime($starttime,$postedtime);
 	}
 
 	//ログ読み込み
@@ -2337,12 +2344,13 @@ function separateDatetimeAndUpdatemark ($now) {
 
 /**
  * 描写時間を計算
- * @param $stime
+ * @param $starttime
  * @return string
  */
-function calcPtime ($stime) {
+function calcPtime ($starttime,$postedtime='') {
 
-	$psec = time() - $stime;
+	$postedtime = $postedtime ? $postedtime : time();
+	$psec = $postedtime - $starttime;
 
 	$D = floor($psec / 86400);
 	$H = floor($psec % 86400 / 3600);


### PR DESCRIPTION
### 「投稿途中の絵」からの投稿でも描画時間がでるように
コメントを記入しなかったお絵かき画像の投稿は「投稿途中の絵」からの投稿になります。
しかし、その場合は描画時間を表示する事ができませんでした。
また、描画時間が入っていても信頼性がかなり低い状態でした。
### 描画時間に関する情報をuserdataに記録する方式への移行
これらの問題を解決するため、描画時間の元となるお絵かき開始時間と終了時間を、userdataに記録するようにしました。
potiboard.phpだけでなく、  
picpost.phpの更新も必要になります。  
picpost.phpの上書きアップデートを同時に行わなければ描画時間は表示されなくなります。