### PR TITLE
コード整理。行数削減。thumbnail_gd.phpの返り値調整。

### DIFF
--- a/potiboard2/thumbnail_gd.php
+++ b/potiboard2/thumbnail_gd.php
@@ -56,7 +56,7 @@ function thumb($path,$tim,$ext,$max_w,$max_h){
 	ImageDestroy($im_in);
 	ImageDestroy($im_out);
 	if(!chmod(THUMB_DIR.$tim.'s.jpg',0606)){
-		return;		
+		return false;
 	}
 
 	$thumbnail_size = [


### PR DESCRIPTION
### function filter_input_default
一箇所でしか使っていない、他の変数で使う訳でもない。
↓
カタログモードでしか使っていないので、ユーザー定義関数を整理。
ほか、global変数をローカル変数に。
コードの変更箇所的にもし動作が変わってしまうとしたら、続きを描く→上書きですがこちらで確認した限りでは問題ありません。
18行短くなりました。
### thumbnail_gd.php
サムネイルの作成に失敗したときの返り値をFalseに変更。
これまではnullが返っていましたが、未定義変数になってnullはあまりよくないのでFalseが返り値になるように調整しました。