### PR TITLE
パレット切り替え機能でパレット名を任意に設定できるように。

### DIFF
--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
-  * POTI-board改二 v2.16 lot.200907
+  * POTI-board改二 v2.17 lot.200908
   * by sakots >> https://poti-k.info/
   *
   * POTI-board改二の設定ファイルです。
@@ -413,9 +413,11 @@ define('USE_SELECT_PALETTES', '0');
 //パレットデータファイル切り替え機能を使用する する:1 の時のパレットデーターファイル名
 //初期パレットpalette.txtとやこうさんパレットpalette.datを切り替えて使う時
 //↓
-$pallets_dat=['palette.txt','palette.dat'];
-//コンマ区切りで複数登録できます。ファイル名は '' で囲ってください。
-// 例 $pallets_dat=['0.txt','1.txt','2.txt'];
+$pallets_dat=array(['標準','palette.txt'],['プロ','palette.dat']);
+// ['パレット名','ファイル名']でひとつ。それをコンマで区切ります。
+//パレット名とファイル名は''で囲ってください。
+//設定例
+//$pallets=array(['パレット名1','palette1.txt'],['パレット名2','palette2.txt'],['パレット名3','palette3.txt']);
 
 //動画機能を使用する する:1 しない:0
 define('USE_ANIME', '1');

--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -417,7 +417,7 @@ $pallets_dat=array(['標準','palette.txt'],['プロ','palette.dat']);
 // ['パレット名','ファイル名']でひとつ。それをコンマで区切ります。
 //パレット名とファイル名は''で囲ってください。
 //設定例
-//$pallets=array(['パレット名1','palette1.txt'],['パレット名2','palette2.txt'],['パレット名3','palette3.txt']);
+//$pallets_dat=array(['パレット1','1.txt'],['パレット2','2.txt'],['パレット3','3.txt']);
 
 //動画機能を使用する する:1 しない:0
 define('USE_ANIME', '1');

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -1505,13 +1505,13 @@ function paintform(){
 	if(USE_SELECT_PALETTES){//パレット切り替え機能を使う時
 		foreach($pallets_dat as $i=>$value){
 			if($i==filter_input(INPUT_POST, 'selected_palette_no',FILTER_VALIDATE_INT)){//キーと入力された数字が同じなら
-					if(is_array($value)){
-						list($p_name,$p_dat)=$value;
-						$lines=file($p_dat);
-					}else{
-						$lines=file($value);
-					}
-					break;
+				if(is_array($value)){
+					list($p_name,$p_dat)=$value;
+					$lines=file($p_dat);
+				}else{
+					$lines=file($value);
+				}
+				break;
 			}
 		}
 	}else{

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -66,10 +66,6 @@ $url = filter_input(INPUT_POST, 'url',FILTER_VALIDATE_URL);
 $sub = filter_input(INPUT_POST, 'sub');
 $com = filter_input(INPUT_POST, 'com');
 $pwd = filter_input(INPUT_POST, 'pwd');
-$picw = filter_input(INPUT_POST, 'picw',FILTER_VALIDATE_INT);
-$pich = filter_input(INPUT_POST, 'pich',FILTER_VALIDATE_INT);
-$anime = filter_input(INPUT_POST, 'anime',FILTER_VALIDATE_BOOLEAN);
-$useneo = filter_input(INPUT_POST, 'useneo',FILTER_VALIDATE_BOOLEAN);
 $no = filter_input(INPUT_POST, 'no',FILTER_VALIDATE_INT);
 $type = newstring(filter_input(INPUT_POST, 'type'));
 $del = filter_input(INPUT_POST,'del',FILTER_VALIDATE_INT,FILTER_REQUIRE_ARRAY);//$del は配列
@@ -217,7 +213,7 @@ switch($mode){
 		redirect(PHP_SELF2, 0);
 		break;
 	case 'paint':
-		paintform($picw,$pich,$anime);
+		paintform();
 		break;
 	case 'piccom':
 		paintcom();
@@ -231,7 +227,7 @@ switch($mode){
 	case 'contpaint':
 //パスワードが必要なのは差し換えの時だけ
 		if(CONTINUE_PASS||$type==='rep') usrchk($no,$pwd);
-		paintform($picw,$pich,$anime);
+		paintform();
 		break;
 	case 'newpost':
 		$dat['post_mode'] = true;
@@ -306,7 +302,7 @@ function get_uip(){
 
 /* ベース */
 function basicpart(){
-	global $pallets_dat; 
+	global $pallets_dat;
 	$dat['title'] = TITLE;
 	$dat['home']  = HOME;
 	$dat['self']  = PHP_SELF;
@@ -327,7 +323,12 @@ function basicpart(){
 	if(USE_SELECT_PALETTES){
 		$dat['use_select_palettes']=true;
 		foreach($pallets_dat as $i=>$value){
-			$arr_palette_select_tags[$i]='<option value="'.$i.'">'.$i.'</option>';
+			if(is_array($value)){
+				list($p_name,$p_dat)=$value;
+			}else{
+				$p_name=$i;
+			}
+			$arr_palette_select_tags[$i]='<option value="'.$i.'">'.$p_name.'</option>';
 		}
 		$dat['palette_select_tags']=implode($arr_palette_select_tags);
 	}
@@ -1351,12 +1352,15 @@ function check_path ($path, $name, $is_dir = false) {
 }
 
 /* お絵描き画面 */
-function paintform($picw,$pich,$anime){
+function paintform(){
 	global $admin,$type,$no,$pwd;
 	global $resto,$mode,$quality,$qualitys,$usercode;
-	global $useneo; //NEOを使う
 	global $ADMIN_PASS,$pallets_dat;
 
+	$picw = filter_input(INPUT_POST, 'picw',FILTER_VALIDATE_INT);
+	$pich = filter_input(INPUT_POST, 'pich',FILTER_VALIDATE_INT);
+	$anime = filter_input(INPUT_POST, 'anime',FILTER_VALIDATE_BOOLEAN);
+	$useneo = filter_input(INPUT_POST, 'useneo',FILTER_VALIDATE_BOOLEAN);
 	$shi = filter_input(INPUT_POST, 'shi',FILTER_VALIDATE_INT);
 	$pch = newstring(filter_input(INPUT_POST, 'pch'));
 	$ext = newstring(filter_input(INPUT_POST, 'ext'));
@@ -1501,8 +1505,13 @@ function paintform($picw,$pich,$anime){
 	if(USE_SELECT_PALETTES){//パレット切り替え機能を使う時
 		foreach($pallets_dat as $i=>$value){
 			if($i==filter_input(INPUT_POST, 'selected_palette_no',FILTER_VALIDATE_INT)){//キーと入力された数字が同じなら
-				$lines=file($pallets_dat[$i]);
-			break;
+					if(is_array($value)){
+						list($p_name,$p_dat)=$value;
+						$lines=file($p_dat);
+					}else{
+						$lines=file($value);
+					}
+					break;
 			}
 		}
 	}else{


### PR DESCRIPTION
### potiboard.php
以前のconfig.phpのパレットデータファイルだけの配列でも動作するように後方互換性を確保しました。
ペイント関連のglobal変数をローカル変数に変更しました。

### config.php
```
//パレットデータファイル切り替え機能を使用する する:1 の時のパレットデーターファイル名
//初期パレットpalette.txtとやこうさんパレットpalette.datを切り替えて使う時
//↓
$pallets_dat=array(['標準','palette.txt'],['プロ','palette.dat']);
```
切り替えるパレットデーターファイルにパレットの名前を設定できるようにしました。
これまでは、配列のキーの番号が表示されていました。
例えばパレットが3つあったら　「0」「1「 2」という数字を切り替えていました。

この更新により上記設定の時は「標準」と「プロ」の切り替えになります。
パレットの名前はユーザーが任意に設定できます。

![image](https://user-images.githubusercontent.com/44894014/92565702-0af4b380-f2b6-11ea-956f-cc10467be097.png)
