### PR TITLE
りファクターとオートリンクの仕様変更とloadcookie.jsの更新

### DIFF
--- a/potiboard2/loadcookie.js
+++ b/potiboard2/loadcookie.js
@@ -25,46 +25,6 @@ function l(e){
 		}
 };
 
-/* Function Equivalent to URLDecoder.decode(String, "UTF-8")
-   Copyright (C) 2002 Cresc Corp. http://www.cresc.co.jp/
-   Version: 1.0
-*/
-function decodeURL(str){
-	var s0, i, j, s, ss, u, n, f;
-	s0 = "";
-	for (i = 0; i < str.length; i++){
-		s = str.charAt(i);
-		if (s == "+"){s0 += " ";}
-		else {
-			if (s != "%"){s0 += s;}
-			else{
-				u = 0;
-				f = 1;
-				while (true) {
-					ss = "";
-					for (j = 0; j < 2; j++ ) {
-						sss = str.charAt(++i);
-						if (((sss >= "0") && (sss <= "9")) || ((sss >= "a") && (sss <= "f"))  || ((sss >= "A") && (sss <= "F"))) {
-							ss += sss;
-						} else {--i; break;}
-					}
-					n = parseInt(ss, 16);
-					if (n <= 0x7f){u = n; f = 1;}
-					if ((n >= 0xc0) && (n <= 0xdf)){u = n & 0x1f; f = 2;}
-					if ((n >= 0xe0) && (n <= 0xef)){u = n & 0x0f; f = 3;}
-					if ((n >= 0xf0) && (n <= 0xf7)){u = n & 0x07; f = 4;}
-					if ((n >= 0x80) && (n <= 0xbf)){u = (u << 6) + (n & 0x3f); --f;}
-					if (f <= 1){break;}
-					if (str.charAt(i + 1) == "%"){ i++ ;}
-					else {break;}
-				}
-				s0 += String.fromCharCode(u);
-			}
-		}
-	}
-	return s0;
-}
-
 /* Function to get cookie parameter value string with specified name
    Copyright (C) 2002 Cresc Corp. http://www.cresc.co.jp/
    Version: 1.0
@@ -77,5 +37,6 @@ function loadCookie(name) {
 	start += name.length + 1;
 	var end = allcookies.indexOf(';',start);
 	if (end == -1) end = allcookies.length;
-	return decodeURL(allcookies.substring(start,end));
+	
+	return decodeURIComponent(allcookies.substring(start,end));
 }

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -2172,19 +2172,18 @@ function create_formatted_text_from_post ($com,$name,$email,$url,$sub){
 	$sub = newstring($sub);
 	$sub = preg_replace("/[\r\n]/","",$sub);
 	$url = newstring($url);
-	$url = preg_replace("/[\r\n]/","",$url);
-	$url = str_replace(array(" ", "　"), "", $url);
+	$url = preg_replace("/\s/u","",$url);//空白と改行を消す
 	$com = newcomment($com);
 
 	// 改行文字の統一。
 	$com = str_replace("\r\n", "\n", $com);
 	$com = str_replace("\r", "\n", $com);
 	// 連続する空行を一行
-	$com = preg_replace("#\n(\s*\n){3,}#","\n",$com);
+	$com = preg_replace("#\n(\s*\n){3,}#u","\n",$com);
 	$com = nl2br($com);		//改行文字の前に<br>を代入する
 	$com = str_replace("\n", "", $com);	//\nを文字列から消す
 
-	$name = preg_replace("/◆/","◇",$name);
+	$name = str_replace("◆", "◇", $name);
 	$name = preg_replace("/[\r\n]/","",$name);
 	$name = newstring($name);
 	$formatted_text = [


### PR DESCRIPTION
### NGワード

NGワードの処理関数に管理モードで使用できるタグを制限する処理を移動しました。

### オートリンク

本文にタグ `<a` がある時は、オートリンクにならないようにしました。
管理モードで`<a href="https://poti-k.info/" target="_blank">POTI改</a>`のようにタグを使ってリンクを作成する時に、オートリンクもかかり、リンクのタグが機能しないからです。
リンクのタグを使って表示したい時に、オートリンクの機能をオフにしなくてもよくなりました。

### テキスト整形

テキスト整形の一連の処理を関数化しました。
書き込みと編集の2箇所を修正しなくても、この関数を変更すれば、書き込み、編集どちらにも反映されるので保守性が向上します。

また正規表現による置換が必要なかったり、そのほか2020年現在の環境では書き直したほうが良い箇所を書き直しました。

### loadcookie.js

CookieのURIエンコードをJavaScriptの組み込み関数  decodeURIComponent に変更しました。
コードを35行短縮する事ができました。
IE5の頃からブラウザはこの関数に対応しておりutf-8しか扱えなくてもPOTI改はutf-8なのでまったく問題ありません。

### HTMLの特殊文字をエスケープする関数の整理

ほとんど同じ処理をしている関数を一つにまとめ、逆に本文は管理者のみタグ許可としている事から別関数に分離しました。