### PR TITLE
キャンバスサイズ、パレット、アプレット選択のCookie対応。

### DIFF
--- a/potiboard2/loadcookie.js
+++ b/potiboard2/loadcookie.js
@@ -1,5 +1,6 @@
-function l(e){
-	var P=loadCookie("pwdc"),N=loadCookie("namec"),E=loadCookie("emailc"),U=loadCookie("urlc"),FC=loadCookie("fcolorc"),i,j;
+function l(){
+	var P=loadCookie("pwdc"),N=loadCookie("namec"),E=loadCookie("emailc"),U=loadCookie("urlc"),
+	FC=loadCookie("fcolorc"),AP=loadCookie("appletc"),PW=loadCookie("picwc"),PH=loadCookie("pichc"),PL=loadCookie("palettec"),i;
 		for(i=0;i<document.forms.length;i++){
 			if(document.forms[i].pwd){
 				document.forms[i].pwd.value=P;
@@ -15,15 +16,51 @@ function l(e){
 			}
 			if(document.forms[i].fcolor){
 				if(FC == "") FC = document.forms[i].fcolor[0].value;
-				for(j = 0; document.forms[i].fcolor.length > j; j ++) {
-					if(document.forms[i].fcolor[j].value == FC){
-						document.forms[i].fcolor[j].checked = true;
-						document.forms[i].fcolor.selectedIndex = j;
-					}
-				}
+
+				checkd_if_formval_equal_cookieval(document.forms[i].fcolor,FC);
+
 			}
+			if(document.forms[i].shi){
+				if(AP == "") AP = document.forms[i].shi[0].value;
+
+				checkd_if_formval_equal_cookieval(document.forms[i].shi,AP);
+
+			}
+			if(document.forms[i].picw){
+				if(PW != ""){
+					document.forms[i].picw.value=PW;
+				}
+
+				checkd_if_formval_equal_cookieval(document.forms[i].picw,PW);
+
+			}
+
+			if(document.forms[i].pich){
+				if(PH != ""){
+					document.forms[i].pich.value=PH;
+				}
+
+				checkd_if_formval_equal_cookieval(document.forms[i].pich,PH);
+
+			}
+
+			if(document.forms[i].selected_palette_no){
+				document.forms[i].selected_palette_no.selectedIndex = PL;
+			}
+
 		}
 };
+
+//Cookieと一致したらcheckd
+function checkd_if_formval_equal_cookieval(docformsname,cookieval) {
+var j;
+	for(j = 0; docformsname.length > j; j ++) {
+	if(docformsname[j].value == cookieval){
+		docformsname[j].checked = true;//チェックボックス
+		docformsname.selectedIndex = j;//プルダウンメニュー
+	}
+}
+}
 
 /* Function to get cookie parameter value string with specified name
    Copyright (C) 2002 Cresc Corp. http://www.cresc.co.jp/

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -42,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.18.9');
-define('POTI_VERLOT' , 'v2.18.9 lot.201101');
+define('POTI_VER' , 'v2.18.10');
+define('POTI_VERLOT' , 'v2.18.10 lot.201103');
 
 if (($phpver = phpversion()) < "5.5.0") {
 	die("本プログラムの動作には PHPバージョン 5.5.0 以上が必要です。<br>\n（現在のPHPバージョン：{$phpver}）");
@@ -1324,6 +1324,11 @@ function paintform(){
 	$ext = newstring(filter_input(INPUT_POST, 'ext'));
 	$ctype = newstring(filter_input(INPUT_POST, 'ctype'));
 
+	//Cookie保存
+	setcookie("appletc", $shi , time()+86400*SAVE_COOKIE);//アプレット選択
+	setcookie("picwc", $picw , time()+86400*SAVE_COOKIE);//幅
+	setcookie("pichc", $pich , time()+86400*SAVE_COOKIE);//高さ
+
 	//pchファイルアップロードペイント
 	if($admin===$ADMIN_PASS){
 		
@@ -1463,6 +1468,7 @@ function paintform(){
 	if(USE_SELECT_PALETTES){//パレット切り替え機能を使う時
 		foreach($pallets_dat as $i=>$value){
 			if($i==filter_input(INPUT_POST, 'selected_palette_no',FILTER_VALIDATE_INT)){//キーと入力された数字が同じなら
+				setcookie("palettec", $i, time()+86400*SAVE_COOKIE);//Cookie保存
 				if(is_array($value)){
 					list($p_name,$p_dat)=$value;
 					$lines=file($p_dat);


### PR DESCRIPTION
### Cookie対応
キャンバスサイズ、パレット、アプレットのそれぞれの値をCookieに保存し、loadcookie.jsで読み込みます。
前回使ったキャンバスサイズ、アプレット、パレットがセットされるようになります。

### キャンバスサイズ
数値直接入力、プルダウンメニューどちらでも対応できます。

![Screen-2020-11-04_00-47-51](https://user-images.githubusercontent.com/44894014/98071932-322bc380-1ea8-11eb-893a-4e12a9c54bcf.png)

○で囲んだ箇所が今回Cookieで記憶するようになった箇所です。

### loadcookie.js

potiboard.phpとloadcookie.jsの更新が必要です。