### PR TITLE
未投稿画像からの投稿でもレス先への投稿になるように

### DIFF
--- a/potiboard2/picpost.php
+++ b/potiboard2/picpost.php
@@ -8,6 +8,7 @@
 // このスクリプトはPaintBBS（藍珠CGI）のPNG保存ルーチンを参考に
 // PHP用に作成したものです。
 //----------------------------------------------------------------------
+// 2020/11/10 レス先の記録に対応。拡張ヘッダの取得を可変変数から連想配列に変更。
 // 2020/08/28 描画時間の記録に対応
 // 2020/05/25 投稿容量制限の設定項目を追加 従来はconfigのMAX_KB
 // 2020/02/25 flock()修正タイムゾーンを'Asia/Tokyo'に
@@ -200,11 +201,15 @@ if($sendheader){
 	$query_str = explode("&", $sendheader);
 	foreach($query_str as $query_s){
 		list($name,$value) = explode("=", $query_s);
-		$$name = $value;
+		$u[$name] = $value;
 	}
+	$usercode = isset($u['usercode']) ? $u['usercode'] : '';
+	$repcode = isset($u['repcode']) ? $u['repcode'] : '';
+	$stime = isset($u['stime']) ? $u['stime'] : '';
+	$time = isset($u['time']) ? $u['time'] : '';
+	$resto = isset($u['resto']) ? $u['resto'] : '';
 	//usercode 差し換え認識コード 描画開始 完了時間 を追加
-	$userdata .= "\t$usercode\t$repcode\t$stime\t$time";
-
+	$userdata .= "\t$usercode\t$repcode\t$stime\t$time\t$resto";
 }
 $userdata .= "\n";
 if(is_file(TEMP_DIR.$imgfile.".dat")){
@@ -217,6 +222,7 @@ if(!$fp){
 	exit;
 }else{
 	flock($fp, LOCK_EX);
+	// fwrite($fp, $userdata);
 	fwrite($fp, $userdata);
 	fflush($fp);
 	flock($fp, LOCK_UN);

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -2185,12 +2185,11 @@ function create_formatted_text_from_post ($com,$name,$email,$url,$sub){
 	// 改行文字の統一。
 	$com = str_replace(["\r\n","\r"], "\n", $com);
 	// 連続する空行を一行
-	$com = preg_replace("#\n(\s*\n){3,}#u","\n",$com);
+	$com = preg_replace("/(\s*\n){4,}/u","\n",$com);
 	$com = nl2br($com);		//改行文字の前に<br>を代入する
 	$com = str_replace("\n", "", $com);	//\nを文字列から消す
-
 	$name = str_replace("◆", "◇", $name);
-	$name = preg_replace("/[\r\n]/","",$name);
+	$name = str_replace(["\r\n","\n","\r"],"",$name);
 	$name = newstring($name);
 	$formatted_text = [
 		'com' => $com,

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -42,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.18.11');
-define('POTI_VERLOT' , 'v2.18.11 lot.201108');
+define('POTI_VER' , 'v2.18.12');
+define('POTI_VERLOT' , 'v2.18.12 lot.201109');
 
 if (($phpver = phpversion()) < "5.5.0") {
 	die("本プログラムの動作には PHPバージョン 5.5.0 以上が必要です。<br>\n（現在のPHPバージョン：{$phpver}）");
@@ -2175,16 +2175,15 @@ function create_formatted_text_from_post ($com,$name,$email,$url,$sub){
 
 	$email = strip_tags($email);
 	$email = newstring($email); 
-	$email = preg_replace("/[\r\n]/","",$email);
+	$email = str_replace(["\r\n","\n","\r"],"",$email);
 	$sub = newstring($sub);
-	$sub = preg_replace("/[\r\n]/","",$sub);
+	$sub = str_replace(["\r\n","\n","\r"],"",$sub);
 	$url = newstring($url);
 	$url = preg_replace("/\s/u","",$url);//空白と改行を消す
 	$com = newcomment($com);
 
 	// 改行文字の統一。
-	$com = str_replace("\r\n", "\n", $com);
-	$com = str_replace("\r", "\n", $com);
+	$com = str_replace(["\r\n","\r"], "\n", $com);
 	// 連続する空行を一行
 	$com = preg_replace("#\n(\s*\n){3,}#u","\n",$com);
 	$com = nl2br($com);		//改行文字の前に<br>を代入する


### PR DESCRIPTION
### 未投稿画像からの投稿でもレス画像になるように

お絵かきの時にコメント未記入で画面を推移すると、未投稿画像からしか投稿できなくなります。
レスでお絵かきして未投稿画像になったら？
これまではレスの筈が新しいスレッドの親の投稿になっていました。
ユーザーデータにレス先の番号を記録する事で、この問題を解決し、未投稿画像からの投稿でもレス画像になるようにしました。
### 上書きアップデートが必要なファイル

potiboard.phpとpicpost.phpの更新が必要です。

### 修正されたバグ
スレッドが削除されていたら新規投稿とする箇所にバグがあり、ツリーが存在しない(スレッドが削除されている）レス先でもレスの投稿になっていました。
しかし、最終的にはツリーの有無を確認するので「スレッドが存在しません」となっていました。

### その他
picpost.phpで使用されていた可変変数は外部から任意の変数名と変数の値を設定可能でした。
残りの行数があまりない箇所での使用なので大きなセキュリティ上の問題はないのかもしれませんが、該当箇所を連想配列を使った値の格納に変更しました。
テキスト整形内の数カ所のpreg_replace()をstr_replace()に置き換えました。