### PR TITLE
フォームが閉じられている指定日数を過ぎた古いスレッドへの投稿はエラーにする。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -829,7 +829,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$resto){
 		if($pictmp==2){//お絵かきは
 			$resto = '';//新規投稿
 		}else{
-			error(MSG025,$dest);//テキストはエラー
+			error(MSG025,$dest);
 		}
 	}
 	if($resto && isset($line[$lineindex[$resto]])){
@@ -838,7 +838,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$resto){
 			if($pictmp==2){//お絵かきは
 				$resto = '';//新規投稿
 			}else{
-				error(MSG001,$dest);//テキストはエラー
+				error(MSG001,$dest);
 			}
 		}
 	}


### PR DESCRIPTION
### フォームが閉じられているスレッドへの投稿はエラーにする

**古いスレッドにレスができないようにする設定項目**
> //指定した日数を過ぎたスレッドのフォームを閉じる
> //define('ELAPSED_DAYS','0');
> //設定しないなら '0'で。フォームを閉じません。
> //define('ELAPSED_DAYS','365');
> //	↑ 365日
> //で1年以上経過したスレッドに返信できなくなります。
> define('ELAPSED_DAYS','365');
> 
この設定の場合は365日経過するとレスのフォームが閉じられます。
しかしフォームを偽造すればレスをつけられる状態でした。

今回の更新により、フォームが閉じられているスレッドへの投稿はエラーになります。
返信が許可されていないスレッドへのレスはできなくなります。