### PR TITLE
動画から続きを描く時のアプレットを自動判定

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -42,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.19.3');
-define('POTI_VERLOT' , 'v2.19.3 lot.201120');
+define('POTI_VER' , 'v2.19.5');
+define('POTI_VERLOT' , 'v2.19.5 lot.201121');
 
 if (($phpver = phpversion()) < "5.5.0") {
 	die("本プログラムの動作には PHPバージョン 5.5.0 以上が必要です。<br>\n（現在のPHPバージョン：{$phpver}）");
@@ -1424,7 +1424,8 @@ function paintform(){
 			$dat['applet'] = true;
 			$dat['usepbbs'] = true;
 			list($picw,$pich)=getimagesize(IMG_DIR.$pch.$ext);//キャンバスサイズ
-		}elseif(is_file(PCH_DIR.$pch.'.pch')){
+		}
+		if(is_file(PCH_DIR.$pch.'.pch')){
 			$dat['applet'] = false;
 		}elseif(is_file(PCH_DIR.$pch.'.spch')){
 			$dat['usepbbs'] = false;

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -1425,10 +1425,14 @@ function paintform(){
 			$dat['usepbbs'] = true;
 			list($picw,$pich)=getimagesize(IMG_DIR.$pch.$ext);//キャンバスサイズ
 		}
-		if(is_file(PCH_DIR.$pch.'.pch')){
+		if(($ctype=='pch') && is_file(PCH_DIR.$pch.'.pch')){
+			$fp = fopen(PCH_DIR.$pch.'.pch', "rb");
+			$useneo = (fread($fp,3)==="NEO"); //先頭3byteを見る
+			fclose($fp);
 			$dat['applet'] = false;
-		}elseif(is_file(PCH_DIR.$pch.'.spch')){
+		}elseif(($ctype=='pch') && is_file(PCH_DIR.$pch.'.spch')){
 			$dat['usepbbs'] = false;
+			$useneo=false;
 		}
 		if((C_SECURITY_CLICK || C_SECURITY_TIMER) && SECURITY_URL){
 			$dat['security'] = true;

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -1425,14 +1425,16 @@ function paintform(){
 			$dat['usepbbs'] = true;
 			list($picw,$pich)=getimagesize(IMG_DIR.$pch.$ext);//キャンバスサイズ
 		}
-		if(($ctype=='pch') && is_file(PCH_DIR.$pch.'.pch')){
+		if(($ctype=='pch') && is_file(PCH_DIR.$pch.'.pch')){//動画から続き
 			$fp = fopen(PCH_DIR.$pch.'.pch', "rb");
 			$useneo = (fread($fp,3)==="NEO"); //先頭3byteを見る
 			fclose($fp);
+			$anime=true;
 			$dat['applet'] = false;
 		}elseif(($ctype=='pch') && is_file(PCH_DIR.$pch.'.spch')){
 			$dat['usepbbs'] = false;
 			$useneo=false;
+			$anime=true;
 		}
 		if((C_SECURITY_CLICK || C_SECURITY_TIMER) && SECURITY_URL){
 			$dat['security'] = true;
@@ -1528,7 +1530,7 @@ function paintform(){
 	$resto = ($resto) ? '&amp;resto='.$resto : '';
 	$dat['mode'] = 'piccom'.$resto;
 	$dat['animeform'] = true;
-	$dat['anime'] = ($anime) ? true : false;
+	$dat['anime'] = $anime ? true : false;
 	if($ctype=='pch'){
 		if ($_pch_ext = check_pch_ext(__DIR__.'/'.PCH_DIR.$pch)) {
 			$dat['pchfile'] = './'.PCH_DIR.$pch.$_pch_ext;


### PR DESCRIPTION
### 動画から続きを描く時にしぃペインターを自動判定
動画から続きを描く時に別のアプレットが起動すると画面に何もでてきません。
例えば、しぃペインターで描いた絵をNEOで開いても描けません。
そうならないようにするため、しぃペインターのspchファイルから続きを描く時はNEOを使うのチェックが入っていてもNEOが起動しないようにしました。

### 動画から続きを描く時にPaintBBS NEOとJavaのPaintBBSを自動判定
PaintBBSとNEOはどちらも動画ファイルの拡張子がpchです。これを区別するため、NEOのpchの中身を調べて先頭の3文字がNEOの時はNEOとして処理し、それ以外はJavaのpchとして処理するようにしました。

### 前回の更新で発生したバグの修正
COOOL SOLIDの設定を変更してお絵かきにどのような項目を出すのかを決める処理のバグが前回の更新発生していました。
すべてのアプレットに設定を変更できる状態になっていたのを修正しました。
![Screen-2020-11-21_15-48-01](https://user-images.githubusercontent.com/44894014/99876489-57575a80-2c3a-11eb-9229-e67214a6eb07.png)

また、画像から続きの時は、すべてのアプレットが使えるように仕様を変更しました。