### PR TITLE
コード整理と著作リンクの修正。

### DIFF
--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
-  * POTI-board改二 v2.20.0 lot.201123
+  * POTI-board改二 v2.20.5 lot.201209
   * by sakots >> https://poti-k.info/
   *
   * POTI-board改二の設定ファイルです。
@@ -447,7 +447,7 @@ define('USE_CONTINUE', '1');
 
 //新規投稿でコンティニューする時にも削除キーが必要 必要:1 不要:0
 //不要:0 で新規投稿なら誰でも続きを描く事ができるようになります。
-define('CONTINUE_PASS', '1');
+define('CONTINUE_PASS', '0');
 
 /* ---------- picpost.php用設定 ---------- */
 //システムログファイル名

--- a/potiboard2/picpost.php
+++ b/potiboard2/picpost.php
@@ -26,7 +26,7 @@
 // 2003/09/10 IPアドレス取得方法変更
 // 2003/09/09 PCHファイルに対応.投稿者情報の記録機能追加
 // 2003/09/01 PHP風(?)に整理
-// 2003/08/28 perl -> php 移植  by TakeponG >> http://www.chomkoubou.com/
+// 2003/08/28 perl -> php 移植  by TakeponG >> https://chomstudio.com/
 // 2003/07/11 perl版初公開
 
 //設定
@@ -208,7 +208,7 @@ if($sendheader){
 	$repcode = isset($u['repcode']) ? $u['repcode'] : '';
 	$stime = isset($u['stime']) ? $u['stime'] : '';
 	$resto = isset($u['resto']) ? $u['resto'] : '';
-	//usercode 差し換え認識コード 描画開始 完了時間 を追加
+	//usercode 差し換え認識コード 描画開始 完了時間 レス先 を追加
 	$userdata .= "\t$usercode\t$repcode\t$stime\t$time\t$resto";
 }
 $userdata .= "\n";

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -42,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.20.3');
-define('POTI_VERLOT' , 'v2.20.3 lot.201207');
+define('POTI_VER' , 'v2.20.5');
+define('POTI_VERLOT' , 'v2.20.5 lot.201209');
 
 if (($phpver = phpversion()) < "5.5.0") {
 	die("本プログラムの動作には PHPバージョン 5.5.0 以上が必要です。<br>\n（現在のPHPバージョン：{$phpver}）");
@@ -2137,7 +2137,6 @@ function charconvert($str){
 /* NGワードがあれば拒絶 */
 function Reject_if_NGword_exists_in_the_post($com,$name,$email,$url,$sub){
 	global $badstring,$badname,$badstr_A,$badstr_B,$pwd,$ADMIN_PASS,$admin;
-	$dest='';
 	//チェックする項目から改行・スペース・タブを消す
 	$chk_com  = preg_replace("/\s/u", "", $com );
 	$chk_name = preg_replace("/\s/u", "", $name );
@@ -2147,29 +2146,29 @@ function Reject_if_NGword_exists_in_the_post($com,$name,$email,$url,$sub){
 	//本文に日本語がなければ拒絶
 	if (USE_JAPANESEFILTER) {
 		mb_regex_encoding("UTF-8");
-		if (strlen($com) > 0 && !preg_match("/[ぁ-んァ-ヶー一-龠]+/u",$chk_com)) error(MSG035,$dest);
+		if (strlen($com) > 0 && !preg_match("/[ぁ-んァ-ヶー一-龠]+/u",$chk_com)) error(MSG035);
 	}
 
 	//本文へのURLの書き込みを禁止
 	if(!($pwd===$ADMIN_PASS||$admin===$ADMIN_PASS)){//どちらも一致しなければ
-		if(DENY_COMMENTS_URL && preg_match('/:\/\/|\.co|\.ly|\.gl|\.net|\.org|\.cc|\.ru|\.su|\.ua|\.gd/i', $com)) error(MSG036,$dest);
+		if(DENY_COMMENTS_URL && preg_match('/:\/\/|\.co|\.ly|\.gl|\.net|\.org|\.cc|\.ru|\.su|\.ua|\.gd/i', $com)) error(MSG036);
 	}
 
 	// 使えない文字チェック
 	if (is_ngword($badstring, [$chk_com, $chk_sub, $chk_name, $chk_email])) {
-		error(MSG032,$dest);
+		error(MSG032);
 	}
 
 	// 使えない名前チェック
 	if (is_ngword($badname, $chk_name)) {
-		error(MSG037,$dest);
+		error(MSG037);
 	}
 
 	//指定文字列が2つあると拒絶
 	$bstr_A_find = is_ngword($badstr_A, [$chk_com, $chk_sub, $chk_name, $chk_email]);
 	$bstr_B_find = is_ngword($badstr_B, [$chk_com, $chk_sub, $chk_name, $chk_email]);
 	if($bstr_A_find && $bstr_B_find){
-		error(MSG032,$dest);
+		error(MSG032);
 	}
 	
 	//管理モードで使用できるタグを制限

--- a/potiboard2/readme.txt
+++ b/potiboard2/readme.txt
@@ -5,14 +5,14 @@
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-　このスクリプトは「レッツPHP!」<http://php.loglog.jp/>の gazou.php を改造
-した、「ふたば★ちゃんねる」<http://www.2chan.net/>の futaba.php を、
+　このスクリプトは「レッツPHP!」 http://php.loglog.jp/ の gazou.php を改造
+した、「ふたば★ちゃんねる」 http://www.2chan.net/ の futaba.php を、
 さらにお絵かきもできるようにして、HTMLテンプレートでデザイン変更できる
-ように改造した「ぷにゅねっと」<http://www.punyu.net/php/>の
+ように改造した「ぷにゅねっと」 http://www.punyu.net/php/ の
 POTI-board v1.32 をさらにphp7に対応させて改造した
-POTI-board改<https://poti-k.info/>を発展させたものです。
+POTI-board改 https://poti-k.info/ を発展させたものです。
 
-　「Skinny」<http://skinny.sx68.net/>
+　「Skinny」 http://skinny.sx68.net/ 
 のおかげで、自由にデザインできるようになってます。
 
 　ちなみに、名前は　Punyu.net　Oekaki　Template　Image　の頭文字を取っ
@@ -105,14 +105,14 @@ potiboard.phpにアクセスするとsrcディレクトリ、thumbディレク�
   ＋--./tmp/       ディレクトリ
   ｜
 ＝＝＝以下のファイルはしぃちゃんのホームページ（Vector）より入手してください＝＝＝＝
-  ｜            <http://hp.vector.co.jp/authors/VA016309/>
+  ｜             http://hp.vector.co.jp/authors/VA016309/ 
   ｜
   ｜PaintBBS.jar     バイナリ ※PaintBBSを使用する場合
   ｜spainter_all.jar バイナリ ※しぃペインターを使用する場合
   ｜PCHViewer.jar    バイナリ ※しぃペインター対応版
   ｜
 ＝＝＝NEOを使用する場合以下をfunigeさんのところから入手してください＝＝＝＝
-  ｜           <https://github.com/funige/neo/>
+  ｜            https://github.com/funige/neo/ 
   ｜
   ｜neo.js
   ｜neo.css
@@ -126,7 +126,7 @@ potiboard.phpにアクセスするとsrcディレクトリ、thumbディレク�
 
 ■thanks!!
 
-　　【ぷにゅねっと<https://www.punyu.net/>SakaQさん】
+　　【ぷにゅねっと https://www.punyu.net/ SakaQさん】
 　POTI改二の親です。
 
 　　【さとぴあさん】
@@ -135,7 +135,7 @@ potiboard.phpにアクセスするとsrcディレクトリ、thumbディレク�
 
 以下SakaQさんのthanks
 
-　　【ちょむ工房<http://www.chomkoubou.com/>のTakeponG殿】
+　　【ちょむ工房 https://chomstudio.com/ のTakeponG殿】
 　picpost.cgi のPHP化ありがとうございます。これのおかげで開発する意欲が
 沸きました。
 
@@ -175,7 +175,7 @@ potiboard.phpにアクセスするとsrcディレクトリ、thumbディレク�
 　PaintBBS(test by v2.22_8)
 　しぃペインター(test by v1.071all)
 　PCH Viewer(test by v1.12)          (C)しぃちゃん「しぃ堂」
-　WCS 動的パレットコントロールセット (C)のらネコ「WonderCatStudio」<http://wondercatstudio.com/>
+　WCS 動的パレットコントロールセット (C)のらネコ「WonderCatStudio」 http://wondercatstudio.com/ 
 
 
 ■変更履歴はgithub参照


### PR DESCRIPTION
### config.php
> //新規投稿でコンティニューする時にも削除キーが必要 必要:1 不要:0
> //不要:0 で新規投稿なら誰でも続きを描く事ができるようになります。	//不要:0 で新規投稿なら誰でも続きを描く事ができるようになります。
> define('CONTINUE_PASS', '1');	define('CONTINUE_PASS', '0');
> 

デフォルト値を0に変更。
理由、パスワードを公開しなくても合作ができる事がわかりにくく、パスワードが公開される事例が多いため。

### 著作リンク
picpost.php 
readme.txt
ちょむ工房URLが現在はまったく別のサイトになっているのを修正。
### potiboard.php 
コード整理。1行短くなりました。