### PR TITLE
$_REQUESTによる$modeの取得を廃止

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -42,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.20.7');
-define('POTI_VERLOT' , 'v2.20.7 lot.201213');
+define('POTI_VER' , 'v2.20.8');
+define('POTI_VERLOT' , 'v2.20.8 lot.201214');
 
 if (($phpver = phpversion()) < "5.5.0") {
 	die("本プログラムの動作には PHPバージョン 5.5.0 以上が必要です。<br>\n（現在のPHPバージョン：{$phpver}）");
@@ -51,7 +51,8 @@ if (($phpver = phpversion()) < "5.5.0") {
 
 //INPUT_POSTから変数を取得
 
-$mode = isset($_REQUEST['mode']) ? $_REQUEST['mode'] : '';
+$mode = filter_input(INPUT_POST, 'mode');
+$mode = $mode ? $mode : filter_input(INPUT_GET, 'mode');
 $resto = filter_input(INPUT_POST, 'resto',FILTER_VALIDATE_INT);
 $name = filter_input(INPUT_POST, 'name');
 $email = filter_input(INPUT_POST, 'email');
@@ -1332,9 +1333,10 @@ function check_dir ($path) {
 /* お絵描き画面 */
 function paintform(){
 	global $admin,$type,$no,$pwd;
-	global $resto,$mode,$quality,$qualitys,$usercode;
+	global $resto,$quality,$qualitys,$usercode;
 	global $ADMIN_PASS,$pallets_dat;
 
+	$mode = filter_input(INPUT_POST, 'mode');
 	$picw = filter_input(INPUT_POST, 'picw',FILTER_VALIDATE_INT);
 	$pich = filter_input(INPUT_POST, 'pich',FILTER_VALIDATE_INT);
 	$anime = filter_input(INPUT_POST, 'anime',FILTER_VALIDATE_BOOLEAN);


### PR DESCRIPTION
[PHP セキュリティに関するチートシート - OWASP](https://jpcertcc.github.io/OWASPdocuments/CheatSheets/PHPSecurity.html)
> $_REQUEST は使用しないことを強くお勧めします。このスーパーグローバル変数をお勧めできない理由は、POST と GET のデータだけでなく、リクエストによって送信された Cookie もこの変数には含まれているからです。  
これらのデータすべてが 1 つの配列にまとめられているため、データのソースの特定がほぼ不可能です。  
これが混乱を招き、コードでミスを犯しやすくなります。  
そのため、セキュリティの問題につながるおそれがあります。

[PHP リクエストパラメータ $_REQUEST[&apos;リクエストパラメータ名&apos;] - Qiita](https://qiita.com/icelandnono/items/2cb7c281ac52dd7bdbd0)

> _POSTの代わりに使うのはNG
> ・つまりなるべく使わない方がいい、postなら$_POST、getなら$_GETにした方がいい
> ・$_REQUESTの値は、デフォルトでは cookie > POST > GETの順で優先されます

IPAから指摘のあった古いscriptの修正箇所をみてみたところ$modeで$_REQUESTを使っていた箇所の修正もはいっていたため調べてみたところ上記のような情報もでてきたので念の為修正しました。
行数も3行増えただけです。