### PR TITLE
PHPが出力するファイル、ディレクトリのパーミッションの値を設定できるようにした。

### DIFF
--- a/potiboard2/Skinny.php
+++ b/potiboard2/Skinny.php
@@ -1,5 +1,6 @@
 <?php
-// オリジナルのSkinnyの以下の箇所を変更しています。パーミッション 0777→0707 0666→0606 変更者 https://poti-k.info/
+//パーミッションの値を設定できるようにした。初期値を 0777→0707 0666→0606 に。
+//変更者 https://poti-k.info/
 /**
  *  Skinny  - One File Simple Template Engine over PHP -
  *  
@@ -47,9 +48,13 @@
 
 $skConf = array();   // Skinny設定情報格納配列
 
-
-
 /**************************************  Skinny config  **************************************/
+
+//パーミッション設定(項目追加者 https://poti-k.info/)
+
+define('SKINNY_PERMISSION_FOR_DIR', 0707);//初期値 0707
+define('SKINNY_PERMISSION_FOR_CACHE', 0707);//初期値 0707
+define('SKINNY_PERMISSION_FOR_ERRORLOG', 0606);//初期値 0606
 
 // 文字エンコード関連
 $skConf['ENCODE']['FLG']      = false;      // 自動文字エンコード変換の利用      [true]:する  false:しない
@@ -154,14 +159,14 @@ ini_set('default_charset', $skConf['ENCODE']['INTERNAL']);
 
 // キャッシュ利用時にキャッシュフォルダを自動生成する
 if($skConf['CACHE']['FLG'] && (!file_exists($skConf['CACHE']['DIR']) || (file_exists($skConf['CACHE']['DIR']) && !is_dir($skConf['CACHE']['DIR'])))) {
-	@mkdir( $skConf['CACHE']['DIR'] , 0707 );
-	@chmod( $skConf['CACHE']['DIR'] , 0707 );
+	@mkdir( $skConf['CACHE']['DIR'] , SKINNY_PERMISSION_FOR_DIR );
+	@chmod( $skConf['CACHE']['DIR'] , SKINNY_PERMISSION_FOR_DIR );
 }
 
 // エラーログ利用時にログフォルダを自動生成する
 if($skConf['ERRORLOG']['FLG'] && (!file_exists($skConf['ERRORLOG']['DIR']) || (file_exists($skConf['ERRORLOG']['DIR']) && !is_dir($skConf['ERRORLOG']['DIR'])))) {
-	@mkdir( $skConf['ERRORLOG']['DIR'] , 0707 );
-	@chmod( $skConf['ERRORLOG']['DIR'] , 0707 );
+	@mkdir( $skConf['ERRORLOG']['DIR'] , SKINNY_PERMISSION_FOR_DIR );
+	@chmod( $skConf['ERRORLOG']['DIR'] , SKINNY_PERMISSION_FOR_DIR );
 }
 
 
@@ -240,7 +245,7 @@ class Skinny {
 				$error_message = date('Y-m-d H:i:s') . "\t" . $str . "\n";
 				$error_logfile = $this->skConf['ERRORLOG']['DIR'] . "/errorlog_" . date('Ymd') . ".log";
 				error_log( $error_message, 3, $error_logfile );
-				chmod( $error_logfile, 0606 );
+				chmod( $error_logfile, SKINNY_PERMISSION_FOR_ERRORLOG );
 				return true;
 			}
 		}
@@ -1230,7 +1235,7 @@ class Skinny {
 			if ( file_put_contents( $cache_name, $code ) === false ) {
 				$this->_skErrorLog( "The cache was not able to write in file. [{$cache_name}]" );
 			} else {
-				chmod( $cache_name, 0707 );
+				chmod( $cache_name, SKINNY_PERMISSION_FOR_CACHE );
 			}
 		}
 		return $code;

--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
-  * POTI-board改二 v2.20.6lot.201212
+  * POTI-board改二 v2.21.1 lot.201220
   * by sakots >> https://poti-k.info/
   *
   * POTI-board改二の設定ファイルです。
@@ -449,6 +449,19 @@ define('USE_CONTINUE', '1');
 //不要:0 で新規投稿なら誰でも続きを描く事ができるようになります。
 define('CONTINUE_PASS', '0');
 
+/* ------------- パーミッション設定 ------------- */
+//PHPが自動的に変更するパーミッションの値。
+//問題なく動作している時は変更しない。
+
+//画像やHTMLファイルのパーミッション。
+define('PERMISSION_FOR_DEST', 0606);//初期値 0606
+//ブラウザから直接呼び出さないログファイルのパーミッション
+define('PERMISSION_FOR_LOG', 0600);//初期値 0600
+//画像や動画ファイルを保存するディレクトリのパーミッション
+define('PERMISSION_FOR_DIR', 0707);//初期値 0707
+
+// Skinny.phpのキャッシュやディレクトリのパーミッションは、
+// Skinny.phpで設定。
 /* ---------- picpost.php用設定 ---------- */
 //システムログファイル名
 $syslog = "picpost.systemlog";

--- a/potiboard2/index.php
+++ b/potiboard2/index.php
@@ -1,6 +1,9 @@
 <?php
 include(__DIR__.'/config.php');
+if(!defined('PERMISSION_FOR_DEST')){//config.phpで未定義なら0606
+	define('PERMISSION_FOR_DEST', 0606);
+}
 header('location: '.PHP_SELF);
-	chmod('index.php',0606);
+	chmod('index.php',PERMISSION_FOR_DEST);
 	unlink('index.php');
 

--- a/potiboard2/picpost.php
+++ b/potiboard2/picpost.php
@@ -1,6 +1,6 @@
 <?php
 //----------------------------------------------------------------------
-// picpost.php lot.201218  by SakaQ >> http://www.punyu.net/php/
+// picpost.php lot.201220  by SakaQ >> http://www.punyu.net/php/
 // & sakots >> https://poti-k.info/
 //
 // しぃからPOSTされたお絵かき画像をTEMPに保存
@@ -8,6 +8,7 @@
 // このスクリプトはPaintBBS（藍珠CGI）のPNG保存ルーチンを参考に
 // PHP用に作成したものです。
 //----------------------------------------------------------------------
+// 2020/12/20 config.phpでパーミッションを設定できるようにした。
 // 2020/12/18 php8対応。画像から続きを描くと投稿できなくなる問題を修正。
 // 2020/11/16 lot.201110の投稿完了時間が記録されないバグを修正。
 // 2020/11/10 レス先の記録に対応。拡張ヘッダの値の取得を可変変数から連想配列に変更。
@@ -32,6 +33,11 @@
 
 //設定
 include(__DIR__.'/config.php');
+
+if(!defined('PERMISSION_FOR_LOG')){//config.phpで未定義なら0600
+	define('PERMISSION_FOR_LOG', 0600);
+}
+
 //タイムゾーン
 date_default_timezone_set('Asia/Tokyo');
 //容量違反チェックをする する:1 しない:0
@@ -228,7 +234,7 @@ if(!$fp){
 	fflush($fp);
 	flock($fp, LOCK_UN);
 	fclose($fp);
-	chmod(TEMP_DIR.$imgfile.'.dat',0600);
+	chmod(TEMP_DIR.$imgfile.'.dat',PERMISSION_FOR_LOG);
 }
 
 die("ok");

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -42,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.21.0');
-define('POTI_VERLOT' , 'v2.21.0 lot.201218');
+define('POTI_VER' , 'v2.21.1');
+define('POTI_VERLOT' , 'v2.21.1 lot.201220');
 
 if (($phpver = phpversion()) < "5.5.0") {
 	die("本プログラムの動作には PHPバージョン 5.5.0 以上が必要です。<br>\n（現在のPHPバージョン：{$phpver}）");
@@ -164,6 +164,16 @@ if(!defined('USE_CHECK_NO_FILE')){//config.phpで未定義なら1
 //描画時間を合計表示に する:1 しない:0 
 if(!defined('TOTAL_PAINTTIME')){//config.phpで未定義なら1
 	define('TOTAL_PAINTTIME', '1');
+}
+
+if(!defined('PERMISSION_FOR_DEST')){//config.phpで未定義なら0606
+	define('PERMISSION_FOR_DEST', 0606);
+}
+if(!defined('PERMISSION_FOR_LOG')){//config.phpで未定義なら0600
+	define('PERMISSION_FOR_LOG', 0600);
+}
+if(!defined('PERMISSION_FOR_DIR')){//config.phpで未定義なら0707
+	define('PERMISSION_FOR_DIR', 0707);
 }
 
 /*-----------Main-------------*/
@@ -550,7 +560,7 @@ function updatelog(){
 		fwrite($fp, $buf);
 		closeFile($fp);
 		//拡張子を.phpにした場合、↑で500エラーでるなら↓に変更
-		if(PHP_EXT!='.php'){chmod($logfilename,0606);}
+		if(PHP_EXT!='.php'){chmod($logfilename,PERMISSION_FOR_DEST);}
 	}
 
 	safe_unlink(($page/PAGE_DEF+1).PHP_EXT);
@@ -745,7 +755,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$resto){
 			if(!USE_IMG_UPLOAD && $admin!==$ADMIN_PASS){//アップロード禁止で管理画面からの投稿ではない時
 				error(MSG006,$upfile);
 			}
-			if(!preg_match('/\A(jpe?g|jfif|gif|png|webp)\z/i', pathinfo($upfile_name, PATHINFO_EXTENSION))){//もとのファイル名の拡張子190606
+			if(!preg_match('/\A(jpe?g|jfif|gif|png|webp)\z/i', pathinfo($upfile_name, PATHINFO_EXTENSION))){//もとのファイル名の拡張子
 				error(MSG004,$upfile);
 			}
 			if(!move_uploaded_file($upfile, $dest)){
@@ -930,7 +940,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$resto){
 		$chk = md5_file($dest);
 		check_badfile($chk, $dest); // 拒絶画像チェック
 
-		chmod($dest,0606);
+		chmod($dest,PERMISSION_FOR_DEST);
 
 		list($W, $H) = getimagesize($dest);
 
@@ -971,7 +981,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$resto){
 			$src = $temppath.$picfile.$pchext;
 			$dst = PCH_DIR.$tim.$pchext;
 			if(copy($src, $dst)){
-				chmod($dst,0606);
+				chmod($dst,PERMISSION_FOR_DEST);
 				unlink($src);
 			}
 		}
@@ -1292,13 +1302,13 @@ function init(){
 		$tim = time() . substr(microtime(),2,3);
 		$testmes="1,".$now.",".DEF_NAME.",,".DEF_SUB.",".DEF_COM.",,,,,,,".$tim.",,,\n";
 		file_put_contents(LOGFILE, $testmes);
-		chmod(LOGFILE, 0600);
+		chmod(LOGFILE, PERMISSION_FOR_LOG);
 	}
 	$err .= check_file(LOGFILE,true);
 
 	if (!is_file(realpath(TREEFILE))) {
 		file_put_contents(TREEFILE, "1\n");
-		chmod(TREEFILE, 0600);
+		chmod(TREEFILE, PERMISSION_FOR_LOG);
 	}
 	$err .= check_file(TREEFILE,true);
 
@@ -1322,8 +1332,8 @@ function check_file ($path,$check_writable='') {
 function check_dir ($path) {
 
 	if (!is_dir($path)) {
-			mkdir($path, 0707);
-			chmod($path, 0707);
+			mkdir($path, PERMISSION_FOR_DIR);
+			chmod($path, PERMISSION_FOR_DIR);
 	}
 	if (!is_dir($path)) return $path . "がありません<br>";
 	if (!is_readable($path)) return $path . "を読めません<br>";
@@ -1980,7 +1990,7 @@ function replace(){
 
 			$imgext = getImgType($img_type, $dest);
 	
-			chmod($dest,0606);
+			chmod($dest,PERMISSION_FOR_DEST);
 			rename($dest,$path.$tim.$imgext);
 			$mes = "画像のアップロードが成功しました<br><br>";
 
@@ -2000,7 +2010,7 @@ function replace(){
 				$src = $temppath . $file_name . $pchext;
 				$dst = PCH_DIR . $tim . $pchext;
 				if(copy($src, $dst)){
-					chmod($dst, 0606);
+					chmod($dst, PERMISSION_FOR_DEST);
 					unlink($src);
 				}
 			}
@@ -2327,7 +2337,7 @@ function png2jpg ($src) {
 			$dst = pathinfo($src, PATHINFO_FILENAME ) . 'jpg.tmp';
 			ImageJPEG($im_in,$dst,98);
 			ImageDestroy($im_in);// 作成したイメージを破棄
-			chmod($dst,0606);
+			chmod($dst,PERMISSION_FOR_DEST);
 			return $dst;
 		}
 	}

--- a/potiboard2/thumbnail_gd.php
+++ b/potiboard2/thumbnail_gd.php
@@ -1,6 +1,9 @@
 <?php
 //サムネイル作成
 //201218 webp形式対応
+if(!defined('PERMISSION_FOR_DEST')){//config.phpで未定義なら0606
+	define('PERMISSION_FOR_DEST', 0606);
+}
 function thumb($path,$tim,$ext,$max_w,$max_h){
 	if(!gd_check()||!function_exists("ImageCreate")||!function_exists("ImageCreateFromJPEG"))return;
 	$fname=$path.$tim.$ext;
@@ -68,7 +71,7 @@ function thumb($path,$tim,$ext,$max_w,$max_h){
 	// 作成したイメージを破棄
 	ImageDestroy($im_in);
 	ImageDestroy($im_out);
-	if(!chmod(THUMB_DIR.$tim.'s.jpg',0606)){
+	if(!chmod(THUMB_DIR.$tim.'s.jpg',PERMISSION_FOR_DEST)){
 		return;
 	}
 


### PR DESCRIPTION
confitg.phpとSkinny.phpに設定項目を追加。
いくつかのファイルに、その設定が反映されるようにしました。
必要がなければconfig.phpに設定項目を追加しなくてOK。設定項目がなければ初期値が入ります。