### PR TITLE
template_ini_phpで設定した投稿者名の敬称がthemeのHTMLに自動的に反映されるようにした。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -145,8 +145,10 @@ if(!defined('DEF_FONTCOLOR')){//文字色選択初期値
 	define('DEF_FONTCOLOR',null);
 }
 
-if(!defined('ADMIN_DELGUSU')||!defined('ADMIN_DELKISU')){//管理画面の色設定
+if(!defined('ADMIN_DELGUSU')){//管理画面の色設定
 	define('ADMIN_DELGUSU',null);
+}
+if(!defined('ADMIN_DELKISU')){//管理画面の色設定
 	define('ADMIN_DELKISU',null);
 }
 
@@ -371,6 +373,7 @@ function basicpart(){
 	if(USE_CHECK_NO_FILE){
 		$dat['hide_the_checkbox_for_nofile']=false;
 	}
+	$dat['_san']=HONORIFIC_SUFFIX;
 
 	return $dat;
 }


### PR DESCRIPTION
日本語版のthemeは「さん」のまま。
他国語版では、ここを変更できるようにする。(ここのコメント部分は開発者向けのコメントなので履歴に書かなくていいはず)