### PR TITLE
picpost.systemlogのパーミッションもconfig.phpで設定できるようにした。(前回の作業の漏れ)

### DIFF
--- a/potiboard2/picpost.php
+++ b/potiboard2/picpost.php
@@ -1,6 +1,6 @@
 <?php
 //----------------------------------------------------------------------
-// picpost.php lot.201220  by SakaQ >> http://www.punyu.net/php/
+// picpost.php lot.210101  by SakaQ >> http://www.punyu.net/php/
 // & sakots >> https://poti-k.info/
 //
 // しぃからPOSTされたお絵かき画像をTEMPに保存
@@ -8,6 +8,7 @@
 // このスクリプトはPaintBBS（藍珠CGI）のPNG保存ルーチンを参考に
 // PHP用に作成したものです。
 //----------------------------------------------------------------------
+// 2021/01/01 エラーログのパーミッションもconfig.phpで設定できるようにした。
 // 2020/12/20 config.phpでパーミッションを設定できるようにした。
 // 2020/12/18 php8対応。画像から続きを描くと投稿できなくなる問題を修正。
 // 2020/11/16 lot.201110の投稿完了時間が記録されないバグを修正。
@@ -37,6 +38,9 @@ include(__DIR__.'/config.php');
 if(!defined('PERMISSION_FOR_LOG')){//config.phpで未定義なら0600
 	define('PERMISSION_FOR_LOG', 0600);
 }
+if(!defined('PERMISSION_FOR_DEST')){//config.phpで未定義なら0606
+	define('PERMISSION_FOR_DEST', 0606);
+}
 
 //タイムゾーン
 if(!defined('DEFAULT_TIMEZONE')){//config.phpで未定義ならAsia/Tokyo
@@ -61,7 +65,7 @@ function error($error){
 	$now = date("y/m/d",$time)."(".(string)$yd.")".date("H:i",$time);
 	if(!is_file($syslog)){//$syslogがなければ作成
 		file_put_contents($syslog,"\n", LOCK_EX);
-		chmod($syslog,0606);
+		chmod($syslog,PERMISSION_FOR_DEST);
 	}
 	$ep = fopen($syslog , "r+") or die($syslog."が開けません");
 	flock($ep, LOCK_EX);
@@ -233,7 +237,6 @@ if(!$fp){
 	exit;
 }else{
 	flock($fp, LOCK_EX);
-	// fwrite($fp, $userdata);
 	fwrite($fp, $userdata);
 	fflush($fp);
 	flock($fp, LOCK_UN);


### PR DESCRIPTION
config.phpですべてのパーミッションの設定が可能になるようにした筈でしたが漏れがみつかりました。
これはその修正です。
picpost.phpでエラーが発生した時に記録するエラーログ(picpost.systemlog)のパーミッションもconfig.phpで設定できるようになりました。