### PR TITLE
PHP8環境で致命的エラーが発生するバグを修正。

### DIFF
--- a/potiboard2/search.php
+++ b/potiboard2/search.php
@@ -1,6 +1,6 @@
 <?php
-//POTI-board plugin search(c)2020 さとぴあ
-//v1.6.5 lot.201218
+//POTI-board plugin search(c)2020-2021 さとぴあ
+//v1.6.6 lot.210117
 //
 //https://pbbs.sakura.ne.jp/
 //フリーウェアですが著作権は放棄しません。
@@ -29,6 +29,7 @@ $max_search=120;
 
 //更新履歴
 
+//v1.6.6 2021.01.17 PHP8環境で致命的エラーが出るバグを修正。1発言分のログが4096バイト以上の時に処理できなくなるバグを修正。
 //v1.6.5 2020.10.02 波ダッシュと全角チルダを区別しない。
 //v1.6.3 2020.09.11 1ページ目の画像の表示枚数が19枚になっていたのを修正。
 //v1.6.2 2020.08.26 画像検索でis_file()のチェックが２重になっていたのを修正。
@@ -52,9 +53,7 @@ require(__DIR__.'/config.php');
 //HTMLテンプレート Skinny
 require_once(__DIR__.'/Skinny.php');
 
-if(!defined('SKIN_DIR')){//config.php で未定義なら /theme
-	define('SKIN_DIR','theme/');
-}
+defined('SKIN_DIR') or define('SKIN_DIR','theme/');//config.php で未定義なら /theme
 
 $dat['skindir']=SKIN_DIR;
 
@@ -86,7 +85,7 @@ $arr=array();
 // $files=array();
 $tree=file(TREEFILE);
 $fp = fopen(LOGFILE, "r");
-while ($line = fgets($fp ,4096)) {
+while ($line = fgets($fp)) {
 	list($no,,$name,,$sub,$com,,,,$ext,,,$time,,,) = explode(",", $line);
 	$continue_to_search=true;
 	if($imgsearch){//画像検索の場合
@@ -155,8 +154,8 @@ if($arr){
 					}
 				}
 
-			$time=substr($time,-13,10);
-			$postedtime = date ("Y/m/d G:i", $time);
+			$time=(int)substr($time,-13,10);
+			$postedtime =$time ? (date("Y/m/d G:i", $time)) : '';
 			$sub=strip_tags($sub);
 			$com=str_replace('<br />',' ',$com);
 			$com=strip_tags($com);
@@ -262,8 +261,8 @@ elseif($page>=$disp_count_of_page+1){
 //最終更新日時を取得
 if($arr){
 	$postedtime=$arr[0]['time'];
-	$postedtime=substr($postedtime,-13,10);
-	$dat['lastmodified']=date("Y/m/d G:i", $postedtime);
+	$postedtime=(int)substr($postedtime,-13,10);
+	$dat['lastmodified']=$postedtime ? (date("Y/m/d G:i", $postedtime)) : '';
 }
 
 unset($arr);


### PR DESCRIPTION
### search.php
PHP8環境で致命的エラーが出るバグを修正。1発言分のログが4096バイト以上の時に処理できなくなるバグを修正。