### PR TITLE
レス表示件数0件と表示される事があるバグを修正。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -42,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.22.2');
-define('POTI_VERLOT' , 'v2.22.2 lot.210105.0');
+define('POTI_VER' , 'v2.22.3');
+define('POTI_VERLOT' , 'v2.22.3 lot.210126');
 
 if (($phpver = phpversion()) < "5.5.0") {
 	die("PHP version 5.5.0 or higher is required for this program to work. <br>\n（Current PHP version:{$phpver}）");
@@ -493,7 +493,7 @@ function updatelog(){
 			// 親レス用の値
 			$res['tab'] = $oya + 1; //TAB
 			$res['limit'] = ($lineindex[$res['no']] >= LOG_MAX * LOG_LIMIT / 100) ? true : ''; // そろそろ消える。
-			$res['skipres'] = $skipres;
+			$res['skipres'] = $skipres ? $skipres : '';
 			$res['resub'] = $resub;
 			$dat['oya'][$oya] = $res;
 


### PR DESCRIPTION
//[新規投稿は管理者のみ]にする する:1 しない:0
//する(1)にした場合、管理者パス以外での新規投稿はできません
define('ADMIN_NEWPOST', '1');

//[新規投稿は管理者のみ]にした場合の 0 はレスを表示しません
define('DSP_RES', '0');
の時に、「レス0件省略」という表示になるバグを修正。
0件省略なので、省略したと表示する意味がない。  

![image](https://user-images.githubusercontent.com/44894014/105862117-c7b39b00-6032-11eb-9013-01a214d8b24e.png)
