### PR TITLE
コード整理。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -42,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.22.3');
-define('POTI_VERLOT' , 'v2.22.3 lot.210126.0');
+define('POTI_VER' , 'v2.22.5');
+define('POTI_VERLOT' , 'v2.22.5 lot.210127');
 
 if (($phpver = phpversion()) < "5.5.0") {
 	die("PHP version 5.5.0 or higher is required for this program to work. <br>\n（Current PHP version:{$phpver}）");
@@ -492,8 +492,8 @@ function updatelog(){
 
 			// 親レス用の値
 			$res['tab'] = $oya + 1; //TAB
-			$res['limit'] = ($lineindex[$res['no']] >= LOG_MAX * LOG_LIMIT / 100) ? true : ''; // そろそろ消える。
-			$res['skipres'] = $skipres ? $skipres : '';
+			$res['limit'] = ($lineindex[$res['no']] >= LOG_MAX * LOG_LIMIT / 100) ? true : false; // そろそろ消える。
+			$res['skipres'] = $skipres ? $skipres : false;
 			$res['resub'] = $resub;
 			$dat['oya'][$oya] = $res;
 
@@ -601,7 +601,7 @@ function res($resno = 0){
 
 	// 親レス用の値
 	$res['tab'] = 1; //TAB
-	$res['limit'] = ($lineindex[$res['no']] >= LOG_MAX * LOG_LIMIT / 100) ? true : ''; // そろそろ消える。
+	$res['limit'] = ($lineindex[$res['no']] >= LOG_MAX * LOG_LIMIT / 100) ? true : false; // そろそろ消える。
 	$res['resub'] = $resub;
 	$res['descriptioncom'] = strip_tags($res['com']); //メタタグに使うコメントからタグを除去
 


### PR DESCRIPTION
```
$res['limit'] = ($lineindex[$res['no']] >= LOG_MAX * LOG_LIMIT / 100) ? true : false; // そろそろ消える。
$res['skipres'] = $skipres ? $skipres : false;
```
ブランクでもSkinnyで未定義扱いになりますが、念のためfalseに書き直しました。
Reed.meにはコード整理と書くだけでいいのかも。
前回の返信が0件省略とでてしまった件も、htmltemplate.incでは　`0` でdefにならなかったものが、Skinny.phpではdefになったからだと思います。