### PR TITLE
picpost.systemlogの設定をpicpost.phpに移動。

### DIFF
--- a/potiboard2/picpost.php
+++ b/potiboard2/picpost.php
@@ -1,6 +1,6 @@
 <?php
 //----------------------------------------------------------------------
-// picpost.php lot.210101  by SakaQ >> http://www.punyu.net/php/
+// picpost.php lot.210130  by SakaQ >> http://www.punyu.net/php/
 // & sakots >> https://poti-k.info/
 //
 // しぃからPOSTされたお絵かき画像をTEMPに保存
@@ -8,6 +8,7 @@
 // このスクリプトはPaintBBS（藍珠CGI）のPNG保存ルーチンを参考に
 // PHP用に作成したものです。
 //----------------------------------------------------------------------
+// 2021/01/30 picpost.systemlogの設定をpicpost.phpに移動。raw POST データ取得処理を整理。
 // 2021/01/01 エラーログのパーミッションもconfig.phpで設定できるようにした。
 // 2020/12/20 config.phpでパーミッションを設定できるようにした。
 // 2020/12/18 php8対応。画像から続きを描くと投稿できなくなる問題を修正。
@@ -34,6 +35,12 @@
 
 //設定
 include(__DIR__.'/config.php');
+
+/* ---------- picpost.php用設定 ---------- */
+// システムログファイル名
+$syslog = isset($syslog) ? $syslog : "picpost.systemlog";
+//システムログ保存件数
+$syslogmax = isset($syslogmax) ? $syslogmax :'100';
 
 if(!defined('PERMISSION_FOR_LOG')){//config.phpで未定義なら0600
 	define('PERMISSION_FOR_LOG', 0600);
@@ -101,11 +108,6 @@ $u_agent = str_replace("\t", "", $u_agent);
 
 //raw POST データ取得
 $buffer = file_get_contents('php://input');
-if(!$buffer){
-	$stdin = @fopen("php://input", "rb");
-	$buffer = @fread($stdin, $_ENV['CONTENT_LENGTH']);
-	@fclose($stdin);
-}
 if(!$buffer){
 	error("データの取得に失敗しました。お絵かき画像は保存されません。");
 	exit;

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -42,8 +42,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 */
 
 //バージョン
-define('POTI_VER' , 'v2.22.5');
-define('POTI_VERLOT' , 'v2.22.5 lot.210127.0');
+define('POTI_VER' , 'v2.22.6');
+define('POTI_VERLOT' , 'v2.22.6 lot.210130');
 
 if (($phpver = phpversion()) < "5.5.0") {
 	die("PHP version 5.5.0 or higher is required for this program to work. <br>\n（Current PHP version:{$phpver}）");
@@ -109,12 +109,6 @@ if ($err = check_file(__DIR__.'/thumbnail_gd.php')) {
 	error($err);
 }
 require(__DIR__.'/thumbnail_gd.php');
-
-/* ---------- picpost.php用設定 ---------- */
-//システムログファイル名
-$syslog = isset($syslog) ? $syslog : "picpost.systemlog";
-//システムログ保存件数
-$syslogmax = isset($syslogmax) ? $syslogmax :'100';
 
 //ユーザー削除権限 (0:不可 1:treeのみ許可 2:treeと画像のみ許可 3:tree,log,画像全て許可)
 //※treeのみを消して後に残ったlogは管理者のみ削除可能


### PR DESCRIPTION
picpost.phpの上書きアップデートをお願いします。
設定の移動先を間違えていたのを修正しました。
開発用のエラーログpicpost.systemlogに関する設定項目をconfig.phpからpotiboard.phpに移動していましたが、その状態ではpicpost.phpに設定を読み込む事ができないため、設定項目をpicpost.php内に移動しました。
このミスにより、同じファイル名の画像がテンプラリに秒単位以下3桁まで同じで存在している時に、致命的エラーになる可能性がありました。(現実的にはほぼありえません)


