### PR TITLE
modeのreturn

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -201,7 +201,7 @@ switch($mode){
 			updatelog();
 			redirect(PHP_SELF2, 0);
 		}
-		break;
+		return;
 	case 'usrdel':
 		if (!USER_DELETES) {
 			error(MSG033);
@@ -209,7 +209,7 @@ switch($mode){
 		usrdel($del,$pwd);
 		updatelog();
 		redirect(PHP_SELF2, 0);
-		break;
+		return;
 	case 'paint':
 		return paintform();
 	case 'piccom':
@@ -241,6 +241,7 @@ switch($mode){
 		}else{
 			redirect(PHP_SELF2, 0);
 		}
+		return;
 }
 
 exit;


### PR DESCRIPTION
modeのSwitch文を通過しない処理はそこで止まる事を明らかにするためにreturnを使用。
returnの返り値は関数ではないので、どこにも使われない。
ただ関数に渡されてそこで処理が続行するだけ。