### PR TITLE
E_WARNINGレベルのエラーが発生していたのを修正

### DIFF
--- a/potiboard2/picpost.php
+++ b/potiboard2/picpost.php
@@ -1,6 +1,6 @@
 <?php
 //----------------------------------------------------------------------
-// picpost.php lot.210203  by SakaQ >> http://www.punyu.net/php/
+// picpost.php lot.210217  by SakaQ >> http://www.punyu.net/php/
 // & sakots >> https://poti-k.info/
 //
 // しぃからPOSTされたお絵かき画像をTEMPに保存
@@ -8,7 +8,7 @@
 // このスクリプトはPaintBBS（藍珠CGI）のPNG保存ルーチンを参考に
 // PHP用に作成したものです。
 //----------------------------------------------------------------------
-// 2021/02/03 コード整理。
+// 2021/02/17 $badfileが未定義の時は拒絶画像の処理をしない。
 // 2021/01/30 picpost.systemlogの設定をpicpost.phpに移動。raw POST データ取得処理を整理。
 // 2021/01/01 エラーログのパーミッションもconfig.phpで設定できるようにした。
 // 2020/12/20 config.phpでパーミッションを設定できるようにした。
@@ -153,11 +153,13 @@ if(!$fp){
 		exit;
 	}
 	$chk = md5_file($full_imgfile);
-	foreach($badfile as $value){
-		if(preg_match("/^$value/",$chk)){
-			unlink($full_imgfile);
-			error("拒絶画像を検出しました。画像は保存されません。");
-			exit;
+	if(isset($badfile)&&is_array($badfile)){
+		foreach($badfile as $value){
+			if(preg_match("/^$value/",$chk)){
+				unlink($full_imgfile);
+				error("拒絶画像を検出しました。画像は保存されません。");
+				exit;
+			}
 		}
 	}
 // }

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -5,8 +5,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 
 // POTI-board改二 
 // バージョン :
-define('POTI_VER','v2.26.1');
-define('POTI_LOT','lot.210215.0'); 
+define('POTI_VER','v2.26.2');
+define('POTI_LOT','lot.210217'); 
 
 /*
   (C)sakots >> https://poti-k.info/
@@ -728,7 +728,7 @@ function regist(){
 		$fp = fopen($temppath.$picfile.".dat", "r");
 		$userdata = fread($fp, 1024);
 		fclose($fp);
-		list($uip,$uhost,,,$ucode,,$starttime,$postedtime,$uresto) = explode("\t", rtrim($userdata));
+		list($uip,$uhost,,,$ucode,,$starttime,$postedtime,$uresto) = explode("\t", rtrim($userdata)."\t");
 		if(($ucode != $usercode) && ($uip != $userip)){error(MSG007);}
 		//描画時間を$userdataをもとに計算
 		if($starttime && DSP_PAINTTIME){
@@ -2165,7 +2165,7 @@ function create_formatted_text_from_post($com,$name,$email,$url,$sub,$fcolor,$de
 	if(!$com||preg_match("/\A\s*\z/u",$com)) $com="";
 	if(!$name||preg_match("/\A\s*\z/u",$name)) $name="";
 	if(!$sub||preg_match("/\A\s*\z/u",$sub))   $sub="";
-	if(!$url||!preg_match("#\Ahttps?://#i",$url)||preg_match("/<|(/i",$url)) $url="";
+	if(!$url||!preg_match("#\Ahttps?://#i",$url)||preg_match("/</i",$url)) $url="";
 	$name = str_replace("◆", "◇", $name);
 	$sage=(stripos($email,'sage')!==false);//メールをバリデートする前にsage判定
 	$email = filter_var($email, FILTER_VALIDATE_EMAIL);


### PR DESCRIPTION
### potiboard.php
E_WARNINGレベルのエラーが発生していたのを修正
タブ区切り文字の右端のタブがtrimされてタブ文字もなくなりエラーになっていたのを修正。
preg_matchで指定した`(`のエスケープが適切ではなかった箇所を修正。`(`そのものを含めない形にした。
URLのリンクのスキームが`https?://`ではじまっている事が確認できれば問題ないと判断。
### picpost.php
config.phpで$badfileが設定されていない時にE_WARNINGレベルのエラーが発生が発生するので、定義されていいて配列である事を確認してから処理を行う形にした。config.phpがただしく設定されていれば問題のない箇所ですが、拒絶画像の設定なんかいらないと考えて消してしまう事もありえるため。(私の絵板がそれでした)