### PR TITLE
バグフィックス

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -1191,7 +1191,10 @@ function userdel(){
 			}
 		}
 	}
-	if(!$flag)error(MSG028);
+	if(!$flag){
+		closeFile($fp);
+		error(MSG028);
+	}
 	if($find){//ログ更新
 		writeFile($fp, implode("\n", $line));
 	}

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -6,7 +6,7 @@ define('USE_DUMP_FOR_DEBUG','0');
 // POTI-board改二 
 // バージョン :
 define('POTI_VER','v2.26.3');
-define('POTI_LOT','lot.210305'); 
+define('POTI_LOT','lot.210306'); 
 
 /*
   (C)sakots >> https://poti-k.info/
@@ -1229,7 +1229,6 @@ function admindel($pass){
 		if(strlen($com) > 20) $com = mb_strcut($com,0,18) . ".";
 		$clip = "";
 		$size = 0;
-		// $chk= "";
 		if($ext && is_file($path.$time.$ext)){
 		$clip = '<a href="'.IMG_DIR.$time.$ext.'" target="_blank" rel="noopener">'.$time.$ext.'</a><br>';
 		$size = filesize($path.$time.$ext);

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -5,8 +5,8 @@ define('USE_DUMP_FOR_DEBUG','0');
 
 // POTI-board改二 
 // バージョン :
-define('POTI_VER','v2.26.2');
-define('POTI_LOT','lot.210217.0'); 
+define('POTI_VER','v2.26.3');
+define('POTI_LOT','lot.210305'); 
 
 /*
   (C)sakots >> https://poti-k.info/
@@ -568,11 +568,10 @@ function res($resno = 0){
 
 	$line = file(LOGFILE);
 	$lineindex = get_lineindex($line); // 逆変換テーブル作成
-
-	$_line = $line[$lineindex[$resno]];
-	if(!isset($_line)){
+	if(!isset($lineindex[$resno])){
 		error(MSG001);
 	}
+	$_line = $line[$lineindex[$resno]];
 
 	$dat = form($resno);
 
@@ -816,14 +815,14 @@ function regist(){
 
 	$lineindex=get_lineindex($line);//逆変換テーブル作成
 
-	if($resto && !isset($line[$lineindex[$resto]])){//レス先のログが存在しない時
+	if($resto && !isset($lineindex[$resto])){//レス先のログが存在しない時
 		if($pictmp==2){//お絵かきは
 			$resto = '';//新規投稿
 		}else{
 			error(MSG025,$dest);
 		}
 	}
-	if($resto && isset($line[$lineindex[$resto]])){
+	if($resto && isset($lineindex[$resto])){
 		list(,,,,,,,,,,,,$res['time'],) = explode(",", $line[$lineindex[$resto]]);
 		if(!check_elapsed_days($res)){//フォームが閉じられていたら
 			if($pictmp==2){//お絵かきは
@@ -992,11 +991,10 @@ function regist(){
 	$newline = "$no,$date,$name,$email,$sub,$com,$url,$host,$pass,$ext,$w,$h,$time,$chk,$ptime,$fcolor\n";
 	$newline.= implode("\n", $line);
 
-	writeFile($fp, $newline);
 
 	//ツリー更新
 	$find = false;
-	$newline = '';
+	$new_treeline = '';
 	$tp=fopen(TREEFILE,"r+");
 	set_file_buffer($tp, 0);
 	flock($tp, LOCK_EX); //*
@@ -1018,9 +1016,9 @@ function regist(){
 			if($_oyano==$resto){
 				$find = TRUE;
 				$line[$i] = rtrim($value).','.$no;
-				$treeline=explode(",", rtrim($line[$i]));
-				if(!$sage || (count($treeline)>MAX_RES)){
-					$newline=$line[$i] . "\n";
+				$treelines=explode(",", rtrim($line[$i]));
+				if(!$sage || (count($treelines)>MAX_RES)){
+					$new_treeline=$line[$i] . "\n";
 					unset($line[$i]);
 				}
 				break;
@@ -1031,14 +1029,16 @@ function regist(){
 		$resto='';
 	}
 	if(!$resto){
-		$newline="$no\n";
+		$new_treeline="$no\n";
 	}
 	if($resto && !$find){
 		error(MSG025,$dest);
 	}
-	$newline.=implode("\n", $line);
+	$new_treeline.=implode("\n", $line);
 
-	writeFile($tp, $newline);
+	writeFile($tp, $new_treeline);
+	writeFile($fp, $newline);
+
 
 	closeFile($tp);
 	closeFile($fp);
@@ -1492,16 +1492,13 @@ function paintform(){
 	$pal=array();
 	$DynP=array();
 	foreach ( $lines as $i => $line ) {
-		$line=charconvert(preg_replace("/[\t\r\n]/","",$line));
+		$line=charconvert(str_replace(["\r","\n","\t"],"",$line));
 		list($pid,$pname,$pal[0],$pal[2],$pal[4],$pal[6],$pal[8],$pal[10],$pal[1],$pal[3],$pal[5],$pal[7],$pal[9],$pal[11],$pal[12],$pal[13]) = explode(",", $line);
 		$DynP[]=newstring($pname);
 		$p_cnt=$i+1;
-		$palettes = 'Palettes['.$p_cnt.'] = "#'.$pal[0];
+		$palettes = 'Palettes['.$p_cnt.'] = "#';
 		ksort($pal);
-		array_shift($pal);
-		foreach ( $pal as $p ) {
-			$palettes.='\n#'.$p;
-		}
+		$palettes.=implode('\n#',$pal);
 		$palettes.='";';//190622
 		$arr_pal[$i] = $palettes;
 	}

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -1125,7 +1125,7 @@ function treedel($delno){
 				}else{//レス削除
 					unset($treeline[$j]);
 					$line[$i]=implode(',', $treeline);
-					$line[$i]=preg_replace("/,,/",",",$line[$i]);
+					$line[$i]=str_replace(",,",",",$line[$i]);
 					$line[$i]=preg_replace("/,\z/","",$line[$i]);
 					if (!$line[$i]) {
 						unset($line[$i]);
@@ -1220,18 +1220,23 @@ function admindel($pass){
 		$name = strip_tags($name);//タグ除去
 		if(strlen($name) > 10) $name = mb_strcut($name,0,9).".";
 		if(strlen($sub) > 10) $sub = mb_strcut($sub,0,9).".";
-		if($email) $name='<a href="mailto:'.$email.'">'.$name.'</a>';
+		if($email){
+			$email=filter_var($email, FILTER_VALIDATE_EMAIL);
+			$name='<a href="mailto:'.$email.'">'.$name.'</a>';
+		}
 		$com = preg_replace("#<br */?>#i"," ",$com);
 		$com = newstring($com);
 		if(strlen($com) > 20) $com = mb_strcut($com,0,18) . ".";
 		$clip = "";
 		$size = 0;
-		$chk= "";
+		// $chk= "";
 		if($ext && is_file($path.$time.$ext)){
 		$clip = '<a href="'.IMG_DIR.$time.$ext.'" target="_blank" rel="noopener">'.$time.$ext.'</a><br>';
 		$size = filesize($path.$time.$ext);
 		$all += $size;	//ファイルサイズ加算
 		$chk= substr($chk,0,10);//md5
+		}else{
+			$chk= "";
 		}
 		$bg = ($j % 2) ? ADMIN_DELGUSU : ADMIN_DELKISU;//背景色
 

--- a/potiboard2/theme/mono_paint.html
+++ b/potiboard2/theme/mono_paint.html
@@ -161,9 +161,6 @@
 						<param name="thumbnail_width" value="100%">
 						<param name="thumbnail_height" value="100%">
 						<param name="tool_advance" value="true">
-						<% def(cpal) %><% each(cpal) %>
-						<param name="color_<% echo(cpal/no) %>" value="#<% echo(cpal/pal) %>">
-						<% /each %><% /def %>
 						<% def(security) %>
 						<% def(security_click) %><param name="security_click" value="<% echo(security_click) %>"><% /def %>
 						<% def(security_timer) %><param name="security_timer" value="<% echo(security_timer) %>"><% /def %>

--- a/potiboard2/theme_nee2/nee2_paint.html
+++ b/potiboard2/theme_nee2/nee2_paint.html
@@ -176,9 +176,6 @@
 						<param name="thumbnail_width" value="100%">
 						<param name="thumbnail_height" value="100%">
 						<param name="tool_advance" value="true">
-						<% def(cpal) %><% each(cpal) %>
-						<param name="color_<% echo(cpal/no) %>" value="#<% echo(cpal/pal) %>">
-						<% /each %><% /def %>
 						<% def(security) %>
 						<% def(security_click) %><param name="security_click" value="<% echo(security_click) %>"><% /def %>
 						<% def(security_timer) %><param name="security_timer" value="<% echo(security_timer) %>"><% /def %>


### PR DESCRIPTION
レス先が存在しないレス投稿の時に、

1. E_WARNINGレベルのエラーが発生するのを修正。 
2. POTIv1.33b1とは別の方法で、img.logへの書き込み処理が発生しないようにした。

ユーザー削除のエラー処理でfopen()したファイルが閉じられていなかったのを修正。

管理者の削除画面の

1. MD5が表示されなくなっていたバグを修正。
2. メアドを検証フィルタに通し、e-mailとして不正な形式のものはリンクに出さないようにした。