### PR TITLE
レス先がない投稿の時にエラーになっても画像が投稿されたままになるバグを修正。続きから描いた時に画像の縦横比が正しくセットされないバグを修正。

### DIFF
--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
-  * POTI-board Kai Ni v2.26.6 lot.210318
+  * POTI-board改二 v2.26.6 lot.210320
   * by sakots >> https://poti-k.info/
   *
   * POTI-board改二の設定ファイルです。

--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
-  * POTI-board改二 v2.23.8 lot.210211
+  * POTI-board Kai Ni v2.26.6 lot.210318
   * by sakots >> https://poti-k.info/
   *
   * POTI-board改二の設定ファイルです。
@@ -23,7 +23,7 @@ define('SKIN_DIR', 'theme/');
 
 //メール通知のほか、シェアボタンなどで使用
 //設置場所のURL。phpのあるディレクトリの'/'まで
-define('ROOT_URL', 'http://www.hoge.ne.jp/oekaki/');
+define('ROOT_URL', 'http://example.com/oekaki/');
 
 
 //掲示板のタイトルタイトル（<title>とTOP）
@@ -122,7 +122,7 @@ $badip = array("addr.dummy.com","addr2.dummy.com");
 define('NOTICE_NOADMIN', '0');
 
 //メール通知先
-define('TO_MAIL', 'root@xxx.xxx');
+define('TO_MAIL', 'xxx@example.com');
 
 //メール通知に本文を付ける 付ける:1 付けない:0
 define('SEND_COM', '1');


### PR DESCRIPTION
レス先が無い投稿の時に添付ファイルでアップロードした画像が画像ディレクトリに残るバグを修正。
続きから描いた時に画像の縦横比が正しくセットされないバグを修正。
 v2.12.7 lot.200822 から関数化された`png2jpg`の作業ディレクトリが、`src`や`tmp`ではなく、`potiboard.php`と同じディレクトリだったのを変更。関数化以前は`src`、今回の変更で`tmp`にした。
`config.php`の設定例に
メイン名の例示のために予約されているセカンドレベルドメイン`example.com`を使用。


